### PR TITLE
Create ra_rdsh_private_autoscale_elb_element

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -8,25 +8,35 @@ Param(
 #Based on:
 # * https://s3.amazonaws.com/app-chemistry/scripts/configure-rdsh.ps1
 
-if (-not $ServerFQDN) {
-    $name = invoke-restmethod -uri http://169.254.169.254/latest/meta-data/public-hostname
-    if (-not $name) {
-        $name = [System.Net.DNS]::GetHostByName('').HostName
+if (-not $ServerFQDN)
+{
+    try
+    {
+        $name = invoke-restmethod -uri http://169.254.169.254/latest/meta-data/public-hostname
+    }
+    catch
+    {
+        if (-not $name)
+        {
+            $name = [System.Net.DNS]::GetHostByName('').HostName
+        }
     }
     $ServerFQDN = $name
 }
 
 $null = Install-WindowsFeature RDS-RD-Server
-$null = Import-Module remotedesktopservices
+$null = Import-Module RemoteDesktop
 
-if ($DomainNetBiosName -and $GroupName) {
+if ($DomainNetBiosName -and $GroupName)
+{
     $group = [ADSI]"WinNT://$env:COMPUTERNAME/Remote Desktop Users,group"
     $groupmembers = @(@($group.Invoke("Members")) | `
         foreach {$_.GetType().InvokeMember("Name", 'GetProperty', $null, $_, $null)})
 
-    if ($groupmembers -notcontains $GroupName) {
-        group.Add("WinNT://$DomainNetBiosName/$GroupName,group")
+    if ($groupmembers -notcontains $GroupName)
+    {
+        $group.Add("WinNT://$DomainNetBiosName/$GroupName,group")
     }
 }
 
-Restart-Computer
+Restart-Computer -Force

--- a/templates/ra_rdsh_private_autoscale_elb_element
+++ b/templates/ra_rdsh_private_autoscale_elb_element
@@ -1,15 +1,15 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description"              : "This templates deploys a Remote Desktop Session Host (RDSH) instance in an autoscale group behind an ELB, and joins the instance to a domain.",
-    "Parameters"               : {
+    "Description" : "This templates deploys a Remote Desktop Session Host (RDSH) instance in an autoscale group behind an ELB, and joins the instance to a domain.",
+    "Parameters" : {
         "KeyPairName" : {
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type"        : "AWS::EC2::KeyPair::KeyName"
+            "Type" : "AWS::EC2::KeyPair::KeyName"
         },
         "RdshInstanceType" : {
             "Description" : "Amazon EC2 instance type for the Remote Desktop Session Instance",
-            "Type"        : "String",
-            "Default"     : "t2.micro",
+            "Type" : "String",
+            "Default" : "t2.micro",
             "AllowedValues" : [
                 "t2.micro",
                 "t2.small",
@@ -23,6 +23,12 @@
         "RdshElbName" : {
             "Description" : "Name of the RDSH Elastic Load Balancer",
             "Type" : "String",
+            "MinLength" : "1"
+        },
+        "RdshLdapContainerOU" : {
+            "Description" : "DN of the LDAP container or OU in which the RDSH instance will be placed",
+            "Type" : "String",
+            "Default" : "CN=Users,DC=example,DC=com",
             "MinLength" : "1"
         },
         "DomainAccessUserGroup" : {
@@ -56,11 +62,6 @@
             "MaxLength"   : "25",
             "AllowedPattern" : "[a-zA-Z0-9]+\\..+"
         },
-        "DomainDNSServers" : {
-            "Description" : "Comma-separated list of IP addresses of DNS Servers. Commonly the Domain Controllers. (e.g. 10.0.0.10,10.0.64.10)",
-            "Type"        : "CommaDelimitedList",
-            "Default"     : "10.0.0.10"
-        },
         "DomainNetBIOSName" : {
             "Description" : "NetBIOS name of the domain (e.g. EXAMPLE)",
             "Type"        : "String",
@@ -72,10 +73,6 @@
         "PrivateSubnetID" : {
             "Description" : "Private Subnet ID where the RDSH instance will run.",
             "Type"        : "AWS::EC2::Subnet::Id"
-        },
-        "SecurityGroupIdDomainMember" : {
-            "Description" : "ID of the security group for Active Directory domain members",
-            "Type"        : "AWS::EC2::SecurityGroup::Id"
         },
         "SecurityGroupIdRDSH" : {
             "Description" : "ID of the security group for RDSH instances",
@@ -112,31 +109,31 @@
         },
         "AWSRegionArch2AMI" : {
             "us-east-1" : {
-                "64" : "ami-1df0ac78"
+                "64" : "ami-e4034a8e"
             },
             "us-west-2" : {
-                "64" : "ami-f8f715cb"
+                "64" : "ami-b25e42d3"
             },
             "us-west-1" : {
-                "64" : "ami-91f93ad5"
+                "64" : "ami-a99df5c9"
             },
             "eu-west-1" : {
-                "64" : "ami-2fcbf458"
+                "64" : "ami-1ffa5a6c"
             },
             "eu-central-1" : {
-                "64" : "ami-f2f5f9ef"
+                "64" : "ami-c64559aa"
             },
             "ap-southeast-1" : {
-                "64" : "ami-faedfea8"
+                "64" : "ami-1992517a"
             },
             "ap-northeast-1" : {
-                "64" : "ami-3e93fe3e"
-            },
-            "sa-east-1" : {
-                "64" : "ami-02952d6e"
+                "64" : "ami-fe436b90"
             },
             "ap-southeast-2" : {
-                "64" : "ami-7bda9041"
+                "64" : "ami-cec69ead"
+            },
+            "sa-east-1" : {
+                "64" : "ami-0abd3966"
             }
         }
     },
@@ -243,29 +240,6 @@
                     },
                     "join" : {
                         "commands" : {
-                            "10-set-dns-servers" : {
-                                "command" : {
-                                    "Fn::Join" : 
-                                    [
-                                        "",
-                                        [
-                                            "powershell.exe -Command \"",
-                                            "Get-NetAdapter | Set-DnsClientServerAddress -ServerAddresses ",
-                                            {
-                                                "Fn::Join" : 
-                                                [
-                                                    ",",
-                                                    {
-                                                        "Ref" : "DomainDNSServers"
-                                                    }
-                                                ]
-                                            },
-                                            " -Verbose\""
-                                        ]
-                                    ]
-                                },
-                                "waitAfterCompletion" : "30"
-                            },
                             "20-join-domain" : {
                                 "command" : {
                                     "Fn::Join" : [
@@ -286,12 +260,16 @@
                                                 "Ref" : "DomainJoinUser"
                                             },
                                             "',",
-                                            "(ConvertTo-SecureString ",
+                                            "(ConvertTo-SecureString '",
                                             {
                                                 "Ref" : "DomainJoinPassword"
                                             },
-                                            " -AsPlainText -Force))) ",
-                                            " -Restart -Verbose\""
+                                            "' -AsPlainText -Force))) ",
+                                            " -OUPath '",
+                                            {
+                                                "Ref": "RdshLdapContainerOU"
+                                            },
+                                            "' -Restart -Verbose\""
                                         ]
                                     ]
                                 },
@@ -380,17 +358,14 @@
                 "BlockDeviceMappings" : [
                     {
                         "DeviceName" : "/dev/sda1",
-                        "Ebs"        : {
+                        "Ebs" : {
                             "VolumeSize" : "50",
-							"VolumeType" : "gp2",
+                            "VolumeType" : "gp2",
                             "DeleteOnTermination" : "true"
                         }
                     }
                 ],
-				"SecurityGroups" : [ 
-                    {
-                        "Ref" : "SecurityGroupIdDomainMember"
-                    },
+                "SecurityGroups" : [
                     {
                         "Ref" : "SecurityGroupIdRDSH"
                     }

--- a/templates/ra_rdsh_private_autoscale_elb_element
+++ b/templates/ra_rdsh_private_autoscale_elb_element
@@ -1,0 +1,416 @@
+{
+    "AWSTemplateFormatVersion" : "2010-09-09",
+    "Description"              : "This templates deploys a Remote Desktop Session Host (RDSH) instance in an autoscale group behind an ELB, and joins the instance to a domain.",
+    "Parameters"               : {
+        "KeyPairName" : {
+            "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
+            "Type"        : "AWS::EC2::KeyPair::KeyName"
+        },
+        "RdshInstanceType" : {
+            "Description" : "Amazon EC2 instance type for the Remote Desktop Session Instance",
+            "Type"        : "String",
+            "Default"     : "t2.micro",
+            "AllowedValues" : [
+                "t2.micro",
+                "t2.small",
+                "t2.medium",
+                "c4.large",
+                "c4.xlarge",
+                "m4.large",
+                "m4.xlarge"
+            ]
+        },
+        "RdshElbName" : {
+            "Description" : "Name of the RDSH Elastic Load Balancer",
+            "Type" : "String",
+            "MinLength" : "1"
+        },
+        "DomainAccessUserGroup" : {
+            "Description" : "Domain group of users authorized to use the RDSH",
+            "Type" : "String",
+            "Default" : "Domain Users",
+            "MinLength" : "1"
+        },
+        "DomainJoinPassword" : {
+            "Description" : "Password for the domain join user. Must be at least 8 characters containing letters, numbers and symbols",
+            "Type"        : "String",
+            "MinLength"   : "8",
+            "MaxLength"   : "32",
+            "AllowedPattern" : "(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*",
+            "NoEcho"         : "true",
+            "Default"        : "Password123"
+        },
+        "DomainJoinUser" : {
+            "Description" : "User name for the account that will join the instance to the domain",
+            "Type"        : "String",
+            "Default"     : "StackAdmin",
+            "MinLength"   : "5",
+            "MaxLength"   : "25",
+            "AllowedPattern" : "[a-zA-Z0-9_]*"
+        },
+        "DomainDNSName" : {
+            "Description" : "Fully qualified domain name (FQDN) of the forest root domain e.g. example.com",
+            "Type"        : "String",
+            "Default"     : "example.com",
+            "MinLength"   : "3",
+            "MaxLength"   : "25",
+            "AllowedPattern" : "[a-zA-Z0-9]+\\..+"
+        },
+        "DomainDNSServers" : {
+            "Description" : "Comma-separated list of IP addresses of DNS Servers. Commonly the Domain Controllers. (e.g. 10.0.0.10,10.0.64.10)",
+            "Type"        : "CommaDelimitedList",
+            "Default"     : "10.0.0.10"
+        },
+        "DomainNetBIOSName" : {
+            "Description" : "NetBIOS name of the domain (e.g. EXAMPLE)",
+            "Type"        : "String",
+            "Default"     : "EXAMPLE",
+            "MinLength"   : "1",
+            "MaxLength"   : "15",
+            "AllowedPattern" : "[a-zA-Z0-9]+"
+        },
+        "PrivateSubnetID" : {
+            "Description" : "Private Subnet ID where the RDSH instance will run.",
+            "Type"        : "AWS::EC2::Subnet::Id"
+        },
+        "SecurityGroupIdDomainMember" : {
+            "Description" : "ID of the security group for Active Directory domain members",
+            "Type"        : "AWS::EC2::SecurityGroup::Id"
+        },
+        "SecurityGroupIdRDSH" : {
+            "Description" : "ID of the security group for RDSH instances",
+            "Type"        : "AWS::EC2::SecurityGroup::Id"
+        },
+        "VPC" : {
+            "Description" : "VPC ID",
+            "Type"        : "AWS::EC2::VPC::Id"
+        }
+    },
+    "Mappings" : {
+        "AWSInstanceType2Arch" : {
+            "t2.micro" : {
+                "Arch" : "64"
+            },
+            "t2.small" : {
+                "Arch" : "64"
+            },
+            "t2.medium" : {
+                "Arch" : "64"
+            },
+            "c4.large" : {
+                "Arch" : "64"
+            },
+            "c4.xlarge" : {
+                "Arch" : "64"
+            },
+            "m4.large" : {
+                "Arch" : "64"
+            },
+            "m4.xlarge" : {
+                "Arch" : "64"
+            }
+        },
+        "AWSRegionArch2AMI" : {
+            "us-east-1" : {
+                "64" : "ami-1df0ac78"
+            },
+            "us-west-2" : {
+                "64" : "ami-f8f715cb"
+            },
+            "us-west-1" : {
+                "64" : "ami-91f93ad5"
+            },
+            "eu-west-1" : {
+                "64" : "ami-2fcbf458"
+            },
+            "eu-central-1" : {
+                "64" : "ami-f2f5f9ef"
+            },
+            "ap-southeast-1" : {
+                "64" : "ami-faedfea8"
+            },
+            "ap-northeast-1" : {
+                "64" : "ami-3e93fe3e"
+            },
+            "sa-east-1" : {
+                "64" : "ami-02952d6e"
+            },
+            "ap-southeast-2" : {
+                "64" : "ami-7bda9041"
+            }
+        }
+    },
+    "Resources" : {
+        "RdshAutoScalingGroup" : {
+            "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "CreationPolicy" : {
+                "ResourceSignal" : {
+                    "Count" : "1",
+                    "Timeout" : "PT30M"
+                }
+            },
+            "Properties" : {
+                "VPCZoneIdentifier" : [ { "Ref" : "PrivateSubnetID" } ],
+                "LaunchConfigurationName" : { "Ref" : "RdshLaunchConfig" },
+                "LoadBalancerNames" : [ { "Ref" : "RdshElbName" } ],
+                "MinSize" : "1",
+                "MaxSize" : "1",
+                "DesiredCapacity" : "1",
+                "HealthCheckGracePeriod" : "3600",
+                "HealthCheckType" : "ELB",
+                "Tags" : [
+                    {
+                        "Key" : "Name",
+                        "Value" : { "Fn::Join" : ["", [
+                            "RDSH-",
+                            { "Ref" : "AWS::StackName" }
+                        ]]},
+                        "PropagateAtLaunch" : "true"
+                    }
+                ]
+            }
+        },
+        "RdshLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Metadata" : {
+                "AWS::CloudFormation::Init" : {
+                    "configSets" : {
+                        "config" : [
+                            "setup",
+                            "join",
+                            "installRDS",
+                            "finalize"
+                        ],
+                        "update" : [
+                            "setup",
+                            "finalize"
+                        ]
+                    },
+                    "setup" : {
+                        "files" : {
+                            "c:\\cfn\\cfn-hup.conf" : {
+                                "content" : {
+                                    "Fn::Join" : [
+                                        "",
+                                        [
+                                            "[main]\n",
+                                            "stack=",
+                                            {
+                                                "Ref" : "AWS::StackName"
+                                            },
+                                            "\n",
+                                            "region=",
+                                            {
+                                                "Ref" : "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf" : {
+                                "content" : {
+                                    "Fn::Join" : [
+                                        "",
+                                        [
+                                            "[cfn-auto-reloader-hook]\n",
+                                            "triggers=post.update\n",
+                                            "path=Resources.RdshLaunchConfig.Metadata.AWS::CloudFormation::Init\n",
+                                            "action=cfn-init.exe -v -c update ",
+                                            "   --stack ", { "Ref" : "AWS::StackName" },
+                                            "   --resource RdshLaunchConfig ",
+                                            "   --region ", { "Ref" : "AWS::Region"}, "\n"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "c:\\cfn\\scripts\\configure-rdsh.ps1" : {
+                                "source" : "https://s3.amazonaws.com/app-chemistry/scripts/configure-rdsh.ps1"
+                            }
+                        },
+                        "services" : {
+                            "windows" : {
+                                "cfn-hup" : {
+                                    "enabled" : "true",
+                                    "ensureRunning" : "true",
+                                    "files"         : [
+                                        "c:\\cfn\\cfn-hup.conf",
+                                        "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "join" : {
+                        "commands" : {
+                            "10-set-dns-servers" : {
+                                "command" : {
+                                    "Fn::Join" : 
+                                    [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"",
+                                            "Get-NetAdapter | Set-DnsClientServerAddress -ServerAddresses ",
+                                            {
+                                                "Fn::Join" : 
+                                                [
+                                                    ",",
+                                                    {
+                                                        "Ref" : "DomainDNSServers"
+                                                    }
+                                                ]
+                                            },
+                                            " -Verbose\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion" : "30"
+                            },
+                            "20-join-domain" : {
+                                "command" : {
+                                    "Fn::Join" : [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"",
+                                            "Add-Computer -DomainName ",
+                                            {
+                                                "Ref" : "DomainDNSName"
+                                            },
+                                            " -Credential ",
+                                            "(New-Object System.Management.Automation.PSCredential('",
+                                            {
+                                                "Ref" : "DomainNetBIOSName"
+                                            },
+                                            "\\",
+                                            {
+                                                "Ref" : "DomainJoinUser"
+                                            },
+                                            "',",
+                                            "(ConvertTo-SecureString ",
+                                            {
+                                                "Ref" : "DomainJoinPassword"
+                                            },
+                                            " -AsPlainText -Force))) ",
+                                            " -Restart -Verbose\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion" : "forever"
+                            }
+                        }
+                    },
+                    "installRDS" : {
+                        "commands" : {
+                            "10-install-rds" : {
+                                "command" : {
+                                    "Fn::Join" : [
+                                        "",
+                                        [
+                                            "powershell.exe \"Install-WindowsFeature RDS-RD-Server -Verbose\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion" : "0"
+                            },
+                            "20-configure-rdsh" : {
+                                "command" : {
+                                    "Fn::Join" : [
+                                        "",
+                                        [
+                                            "powershell.exe -ExecutionPolicy Bypass",
+                                            " C:\\cfn\\scripts\\configure-rdsh.ps1 ",
+                                            " -DomainNetBiosName ", { "Ref" : "DomainNetBIOSName" },
+                                            " -GroupName ",
+                                            "'",
+                                            { "Ref" : "DomainAccessUserGroup" },
+                                            "'",
+                                            " -Verbose"
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion" : "forever"
+                            }
+                        }
+                    },
+                    "finalize" : {
+                        "commands" : {
+                            "10-signal-success" : {
+                                "command" : {
+                                    "Fn::Join" : [
+                                        "",
+                                        [
+                                            "cfn-signal.exe -e 0 ",
+                                            "   --stack ", { "Ref" : "AWS::StackName" },
+                                            "   --resource RdshAutoScalingGroup ",
+                                            "   --region ", { "Ref" : "AWS::Region"}
+                                        ]
+                                    ]
+                                },
+                                "ignoreErrors" : "true",
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    }
+                }
+            },
+            "Properties" : {
+                "ImageId" : {
+                    "Fn::FindInMap" : [
+                        "AWSRegionArch2AMI",
+                        {
+                            "Ref" : "AWS::Region"
+                        },
+                        {
+                            "Fn::FindInMap" : [
+                                "AWSInstanceType2Arch",
+                                {
+                                    "Ref" : "RdshInstanceType"
+                                },
+                                "Arch"
+                            ]
+                        }
+                    ]
+                },
+                "InstanceType" : {
+                    "Ref" : "RdshInstanceType"
+                },
+                "KeyName" : {
+                    "Ref" : "KeyPairName"
+                },
+                "BlockDeviceMappings" : [
+                    {
+                        "DeviceName" : "/dev/sda1",
+                        "Ebs"        : {
+                            "VolumeSize" : "50",
+							"VolumeType" : "gp2",
+                            "DeleteOnTermination" : "true"
+                        }
+                    }
+                ],
+				"SecurityGroups" : [ 
+                    {
+                        "Ref" : "SecurityGroupIdDomainMember"
+                    },
+                    {
+                        "Ref" : "SecurityGroupIdRDSH"
+                    }
+                ],
+                "UserData" : {
+                    "Fn::Base64" : {
+                        "Fn::Join" : [
+                            "",
+                            [
+                                "<script>\n",
+                                "cfn-init.exe -v -c config ",
+                                "   --stack ", { "Ref" : "AWS::StackName" },
+                                "   --resource RdshLaunchConfig ",
+                                "   --region ", { "Ref" : "AWS::Region"}, "\n",
+                                "</script>\n"
+                            ]
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This templates deploys a Remote Desktop Session Host (RDSH) instance in an autoscale group behind an ELB, and joins the instance to a domain.