### PR TITLE
guac: remove apache, build freerdp from source

### DIFF
--- a/scripts/make-guac.sh
+++ b/scripts/make-guac.sh
@@ -440,16 +440,29 @@ log "Adding a proxy-directive to Apache, /etc/httpd/conf.d/Guacamole-proxy.conf"
     printf "\tProxyPass http://localhost:8080/guacamole/"
     printf " flushpackets=on\n"
     printf "\tProxyPassReverse http://localhost:8080/guacamole/\n"
-    printf "\tProxyPassReverseCookiePath /guacamole/ /guacamole/\n"
+    printf "</Location>\n"
+    printf "\n"
+    printf "<Location /websocket-tunnel>\n"
+    printf "\tOrder allow,deny\n"
+    printf "\tAllow from all\n"
+    printf "\tProxyPass ws://localhost:8080/guacamole/websocket-tunnel\n"
+    printf "\tProxyPassReverse ws://localhost:8080/guacamole/websocket-tunnel\n"
     printf "</Location>\n"
     printf "\n"
     printf "<Location /guacamole/websocket-tunnel>\n"
     printf "\tOrder allow,deny\n"
     printf "\tAllow from all\n"
-    printf "\tProxyPass ws://localhost:8080//guacamole/websocket-tunnel\n"
-    printf "\tProxyPassReverse ws://localhost:8080//guacamole/websocket-tunnel\n"
+    printf "\tProxyPass ws://localhost:8080/guacamole/websocket-tunnel\n"
+    printf "\tProxyPassReverse ws://localhost:8080/guacamole/websocket-tunnel\n"
     printf "</Location>\n"
 ) > /etc/httpd/conf.d/Guacamole-proxy.conf
+
+
+log "Adding websocket proxy to Apache"
+(
+    printf "LoadModule proxy_module modules/mod_proxy.so\n"
+    printf "LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n"
+) > /etc/httpd/conf.modules.d/00-guacamole.conf
 
 
 log "Link guacamole to /etc/guacamole"

--- a/scripts/make-guac.sh
+++ b/scripts/make-guac.sh
@@ -16,7 +16,7 @@
 #
 #################################################################
 __ScriptName="make-guac.sh"
-__GuacVersion="0.9.7"
+__GuacVersion="0.9.9"
 
 log()
 {
@@ -197,7 +197,8 @@ GUACPASS_MD5=$(__md5sum "${GUAC_PASSWORD}")
 GUAC_SOURCE="http://sourceforge.net/projects/guacamole/files/current/source"
 GUAC_BINARY="http://sourceforge.net/projects/guacamole/files/current/binary"
 GUAC_EXTENSIONS="http://sourceforge.net/projects/guacamole/files/current/extensions"
-FREERDP_SOURCE="http://pub.freerdp.com/releases/freerdp-1.1.0-beta+2013071101.tar.gz"
+FREERDP_REPO="git://github.com/FreeRDP/FreeRDP.git"
+FREERDP_BRANCH="stable-1.1"
 ADDUSER="/usr/sbin/useradd"
 MODUSER="/usr/sbin/usermod"
 
@@ -220,21 +221,21 @@ yum-config-manager --enable epel base
 log "Installing OS standard Tomcat"
 yum install -y tomcat7
 
-log "Installing libraries to build freerdp from source"
-yum install gcc cmake openssl-devel libX11-devel libXext-devel \
+log "Installing utils and libraries to build freerdp from source"
+yum -y install git gcc cmake openssl-devel libX11-devel libXext-devel \
     libXinerama-devel libXcursor-devel libXi-devel libXdamage-devel \
     libXv-devel libxkbfile-devel alsa-lib-devel cups-devel ffmpeg-devel \
     glib2-devel
 
 # Build freerdp
 cd /root
-FREERDP_FILENAME=$(echo ${FREERDP_SOURCE} | awk -F'/' '{ print ( $(NF) ) }')
-FREERDP_FILEBASE=$(basename -s .tar.gz ${FREERDP_FILENAME})
-rm -rf "${FREERDP_BASENAME}"
-log "Downloading and extracting ${FREERDP_FILENAME}"
-(curl -s -L "${FREERDP_SOURCE}" | tar -xzv) || \
-    die "Could not download and extract ${FREERDP_FILENAME}"
-cd "${FREERDP_FILEBASE}"
+FREERDP_BASE=$(basename -s .git ${FREERDP_REPO})
+rm -rf "${FREERDP_BASE}"
+git clone "${FREERDP_REPO}" || \
+    die "Could not clone ${FREERDP_REPO}"
+cd "${FREERDP_BASE}"
+git checkout "${FREERDP_BRANCH}" || \
+    die "Could not checkout branch ${FREERDP_BRANCH}"
 log "Building ${FREERDP_FILEBASE} from source"
 cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_SSE2=ON -DWITH_DEBUG_ALL=ON .
 make

--- a/scripts/make-guac.sh
+++ b/scripts/make-guac.sh
@@ -305,7 +305,20 @@ log "Writing /etc/guacamole/logback.xml"
     printf "\n"
     printf "</configuration>\n"
 ) > /etc/guacamole/logback.xml
-
+log "Writing /etc/guacamole/guacd.conf"
+(
+    printf "# guacd configuration file\n\n"
+    printf "[daemon]\n"
+    printf "log_level = debug\n"
+) > /etc/guacamole/guacd.conf
+log "Writing /etc/rsyslog.d/00-guacd.conf"
+(
+    printf "# Log guacd generated log messages to file\n"
+    printf ":syslogtag, startswith, "guacd" /var/log/guacd.log\n\n"
+    printf "# comment out the following line to allow GUACD messages through.\n"
+    printf "# Doing so means you'll also get GUACD messages in /var/log/syslog\n"
+    printf "& ~\n"
+) > /etc/rsyslog.d/00-guacd.conf
 
 if [ -n "${GUAC_USERNAME}" ]
 then

--- a/scripts/make-guac.sh
+++ b/scripts/make-guac.sh
@@ -291,14 +291,14 @@ done
 # Install the Guacamole client
 log "Downloading Guacamole client from project repo"
 curl -s -L ${GUAC_BINARY}/guacamole-${GUAC_VERSION}.war/download \
-    -o /var/lib/tomcat7/webapps/guacamole.war
+    -o /var/lib/tomcat7/webapps/ROOT.war
 
 
 # Gotta make SELinux happy...
 if [[ $(getenforce) = "Enforcing" ]] || [[ $(getenforce) = "Permissive" ]]
 then
     chcon -R --reference=/var/lib/tomcat7/webapps \
-        /var/lib/tomcat7/webapps/guacamole.war
+        /var/lib/tomcat7/webapps/ROOT.war
     if [[ $(getsebool httpd_can_network_relay | \
         cut -d ">" -f 2 | sed 's/[ ]*//g') = "off" ]]
     then
@@ -464,18 +464,6 @@ echo "setenv GUACAMOLE_HOME /etc/guacamole" > /etc/profile.d/guacamole.csh
 
 log "Setting SEL contexts on shell-init files"
 chcon system_u:object_r:bin_t:s0 /etc/profile.d/guacamole.*
-
-
-log "Link guacamole to /etc/guacamole"
-if [[ ! -d /usr/share/tomcat7/.guacamole ]]
-then
-    mkdir /usr/share/tomcat7/.guacamole
-fi
-cd /usr/share/tomcat7/.guacamole
-for FILE in /etc/guacamole/*
-do
-    ln -sf ${FILE}
-done
 
 
 log "Ensuring freerdp plugins are linked properly"

--- a/scripts/make-guac.sh
+++ b/scripts/make-guac.sh
@@ -217,8 +217,8 @@ curl -s -L "https://raw.githubusercontent.com/plus3it/cfn/master/scripts/RPM-GPG
 log "Enabling the EPEL and base repos"
 yum-config-manager --enable epel base
 
-log "Installing OS standard Tomcat and Apache"
-yum install -y httpd24 tomcat7
+log "Installing OS standard Tomcat"
+yum install -y tomcat7
 
 log "Installing libraries to build freerdp from source"
 yum install gcc cmake openssl-devel libX11-devel libXext-devel \
@@ -269,7 +269,7 @@ make install
 ldconfig
 
 log "Enabling services to start at next boot"
-for SVC in httpd tomcat7 guacd
+for SVC in tomcat7 guacd
 do
     chkconfig ${SVC} on
 done
@@ -466,48 +466,6 @@ log "Setting SEL contexts on shell-init files"
 chcon system_u:object_r:bin_t:s0 /etc/profile.d/guacamole.*
 
 
-log "Adding a proxy-directive to Apache, /etc/httpd/conf.d/Guacamole-proxy.conf"
-(
-    printf "<Location />\n"
-    printf "\tOrder allow,deny\n"
-    printf "\tAllow from all\n"
-    printf "\tProxyPass http://localhost:8080/guacamole/"
-    printf " flushpackets=on\n"
-    printf "\tProxyPassReverse http://localhost:8080/guacamole/\n"
-    printf "\tProxyPassReverseCookiePath /guacamole/ /\n"
-    printf "</Location>\n"
-    printf "\n"
-    printf "<Location /guacamole/>\n"
-    printf "\tOrder allow,deny\n"
-    printf "\tAllow from all\n"
-    printf "\tProxyPass http://localhost:8080/guacamole/"
-    printf " flushpackets=on\n"
-    printf "\tProxyPassReverse http://localhost:8080/guacamole/\n"
-    printf "</Location>\n"
-    printf "\n"
-    printf "<Location /websocket-tunnel>\n"
-    printf "\tOrder allow,deny\n"
-    printf "\tAllow from all\n"
-    printf "\tProxyPass ws://localhost:8080/guacamole/websocket-tunnel\n"
-    printf "\tProxyPassReverse ws://localhost:8080/guacamole/websocket-tunnel\n"
-    printf "</Location>\n"
-    printf "\n"
-    printf "<Location /guacamole/websocket-tunnel>\n"
-    printf "\tOrder allow,deny\n"
-    printf "\tAllow from all\n"
-    printf "\tProxyPass ws://localhost:8080/guacamole/websocket-tunnel\n"
-    printf "\tProxyPassReverse ws://localhost:8080/guacamole/websocket-tunnel\n"
-    printf "</Location>\n"
-) > /etc/httpd/conf.d/Guacamole-proxy.conf
-
-
-log "Adding websocket proxy to Apache"
-(
-    printf "LoadModule proxy_module modules/mod_proxy.so\n"
-    printf "LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so\n"
-) > /etc/httpd/conf.modules.d/00-guacamole.conf
-
-
 log "Link guacamole to /etc/guacamole"
 if [[ ! -d /usr/share/tomcat7/.guacamole ]]
 then
@@ -550,7 +508,7 @@ fi
 
 # Start services
 log "Attempting to start proxy-related services"
-for SVC in rsyslog guacd tomcat7 httpd
+for SVC in rsyslog guacd tomcat7
 do
     log "Stopping and starting ${SVC}"
     /sbin/service ${SVC} stop && /sbin/service ${SVC} start

--- a/templates/ra_guac_elb_public_ssl_443.element
+++ b/templates/ra_guac_elb_public_ssl_443.element
@@ -39,6 +39,9 @@
                     "Timeout" : "5",
                     "UnhealthyThreshold" : "10"
                 },
+                "ConnectionSettings" : {
+                    "IdleTimeout" : "900"
+                },
                 "LBCookieStickinessPolicy" : [
                     {
                         "PolicyName" : "guac-lb-cookie-policy"

--- a/templates/ra_guac_elb_public_ssl_443.element
+++ b/templates/ra_guac_elb_public_ssl_443.element
@@ -35,7 +35,7 @@
                 "HealthCheck" : {
                     "HealthyThreshold" : "5",
                     "Interval" : "60",
-                    "Target" : "HTTP:8080/guacamole/",
+                    "Target" : "HTTP:8080/",
                     "Timeout" : "5",
                     "UnhealthyThreshold" : "10"
                 },

--- a/templates/ra_guac_elb_public_ssl_443.element
+++ b/templates/ra_guac_elb_public_ssl_443.element
@@ -35,7 +35,7 @@
                 "HealthCheck" : {
                     "HealthyThreshold" : "5",
                     "Interval" : "60",
-                    "Target" : "HTTP:80/guacamole/",
+                    "Target" : "HTTP:8080/guacamole/",
                     "Timeout" : "5",
                     "UnhealthyThreshold" : "10"
                 },
@@ -49,7 +49,7 @@
                 ],
                 "Listeners" : [
                     {
-                        "InstancePort" : "80",
+                        "InstancePort" : "8080",
                         "InstanceProtocol" : "HTTP",
                         "LoadBalancerPort" : "443",
                         "PolicyNames" : [

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -73,7 +73,7 @@
         "GuacVersion" : {
             "Description" : "Version of Guacamole to install",
             "Type" : "String",
-            "Default" : "0.9.7",
+            "Default" : "0.9.9",
             "MinLength" : "1"
         },
         "PrivateSubnetIDs" : {

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -330,43 +330,68 @@
                         "Fn::Join" : [
                             "",
                             [
-                                "#!/bin/bash -xe\n",
+                                "#!/bin/bash -xe\n\n",
 
                                 "# CFN LaunchConfig Update Toggle: ",
                                 { "Ref" : "ForceUpdateToggle" },
-                                "\n",
+                                "\n\n",
 
                                 "# Get pip\n",
-                                "curl https://bootstrap.pypa.io/get-pip.py | python\n",
-                                "hash pip 2> /dev/null || PATH=\"${PATH}:/usr/local/bin\"\n",
+                                "curl --silent --show-error --retry 5 -L ",
+                                "https://bootstrap.pypa.io/get-pip.py",
+                                " | python", "\n\n",
+
+                                "# Add pip to path\n",
+                                "hash pip 2> /dev/null || ",
+                                "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
 
                                 "# Upgrade setuptools\n",
-                                "pip install --upgrade setuptools\n",
+                                "pip install --upgrade setuptools\n\n",
 
                                 "# Fix python urllib3 warnings\n",
                                 "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-                                "pip install pyopenssl ndg-httpsclient pyasn1\n",
+                                "pip install pyopenssl ndg-httpsclient pyasn1\n\n",
 
-                                "# Get cfn scripts\n",
-                                "#pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
-                                "#chmod 775 /opt/aws/apitools/cfn-init/init/redhat/cfn-hup\n",
-                                "#ln -f -s /opt/aws/apitools/cfn-init/init/redhat/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
-                                "#chkconfig --add cfn-hup\n",
-                                "#chkconfig cfn-hup on\n",
-                                "#mkdir -p /opt/aws/bin\n",
-                                "#for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup",
-                                " cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
-                                "#do\n",
-                                "#    ln -f -s /usr/bin/${SCRIPT} /opt/aws/bin/${SCRIPT}\n",
-                                "#done\n",
+                                "# Get cfn utils\n",
+                                "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n\n",
 
-                                "yum -y install aws-cfn-bootstrap\n",
+                                "# Remove gcc now that it is no longer needed\n",
+                                "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+
+                                "# Fixup cfn utils\n",
+                                "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
+                                "2> /dev/null || echo /usr/init/redhat)\n",
+                                "chmod 775 ${INITDIR}/cfn-hup\n",
+                                "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                                "chkconfig --add cfn-hup\n",
+                                "chkconfig cfn-hup on\n",
+                                "mkdir -p /opt/aws/bin\n",
+                                "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
+                                "2> /dev/null || echo /usr/bin)\n",
+                                "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
+                                "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                                "do\n",
+                                "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                                "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                                "done\n\n",
+
+                                "# Add cfn-signal to path\n",
+                                "hash cfn-signal 2> /dev/null || ",
+                                "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
+                                "\n\n",
 
                                 "# Execute cfn-init\n",
-                                "/opt/aws/bin/cfn-init -v -c config ",
-                                "    --stack ", { "Ref" : "AWS::StackName" },
-                                "    --resource GuacLaunchConfig ",
-                                "    --region ", { "Ref" : "AWS::Region" }, "\n"
+                                "/opt/aws/bin/cfn-init -v -c config",
+                                " --stack ", { "Ref" : "AWS::StackName" },
+                                " --resource GuacLaunchConfig ",
+                                " --region ", { "Ref" : "AWS::Region" }, " ||",
+                                " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                                " /opt/aws/bin/cfn-signal -e 1",
+                                "  --stack ", { "Ref" : "AWS::StackName" },
+                                "  --resource SystemPrepAutoScalingGroup",
+                                "  --region ", { "Ref" : "AWS::Region"}, ";",
+                                " exit 1",
+                                " )\n\n"
                             ]
                         ]
                     }

--- a/templates/ra_guac_security_group.element
+++ b/templates/ra_guac_security_group.element
@@ -25,14 +25,6 @@
                 "VpcId" : {
                     "Ref" : "VPC"
                 },
-                "SecurityGroupIngress" : [
-                    {
-                        "IpProtocol" : "icmp",
-                        "FromPort"   : "-1",
-                        "ToPort"     : "-1",
-                        "CidrIp"     : "0.0.0.0/0"
-                    }
-                ],
                 "Tags" : [
                     {
                         "Key" : "Name",
@@ -44,14 +36,14 @@
                 ]
             }
         },
-        "PublicToGuacIngressTcp80" : {
+        "PublicToGuacIngressTcp8080" : {
             "Type" : "AWS::EC2::SecurityGroupIngress",
             "Condition" : "NoELB",
             "Properties" : {
                 "GroupId" :  { "Ref": "GuacSecurityGroup" },
                 "IpProtocol" : "tcp",
-                "FromPort"   : "80",
-                "ToPort"     : "80",
+                "FromPort"   : "8080",
+                "ToPort"     : "8080",
                 "CidrIp" : "0.0.0.0/0"
             }
         },
@@ -61,8 +53,8 @@
             "Properties" : {
                 "GroupId" :  { "Ref": "GuacSecurityGroup" },
                 "IpProtocol" : "tcp",
-                "FromPort"   : "80",
-                "ToPort"     : "80",
+                "FromPort"   : "8080",
+                "ToPort"     : "8080",
                 "SourceSecurityGroupId" : { "Ref": "GuacElbSecurityGroup" }
             }
         },
@@ -102,8 +94,8 @@
             "Properties" : {
                 "GroupId" :  { "Ref": "GuacElbSecurityGroup" },
                 "IpProtocol" : "tcp",
-                "FromPort"   : "80",
-                "ToPort"     : "80",
+                "FromPort"   : "8080",
+                "ToPort"     : "8080",
                 "DestinationSecurityGroupId" : { "Ref": "GuacSecurityGroup" }
             }
         }

--- a/templates/ra_multiaz_guac_elb.compound
+++ b/templates/ra_multiaz_guac_elb.compound
@@ -74,7 +74,7 @@
         "GuacVersion" : {
             "Description" : "Version of Guacamole to install",
             "Type" : "String",
-            "Default" : "0.9.7",
+            "Default" : "0.9.9",
             "MinLength" : "1"
         },
         "InstanceType" : {


### PR DESCRIPTION
This set of commits removes apache from the guac build as it was not providing any extra functionality. Also, Freerdp is now built from source, using the stable-1.1 branch, to take advantage of continued development (the previous version had been mostly deprecated for over two years).