### PR TITLE
Update DC2IP Parameters passed to nw_r53 element

### DIFF
--- a/templates/nw_dualaz_multitier_nat_with_eni.compound
+++ b/templates/nw_dualaz_multitier_nat_with_eni.compound
@@ -361,7 +361,7 @@
                     "PeeredDc1Name" : { "Ref" : "VpcPeerDc1Name" },
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
-                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc1Ip" },
+                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }

--- a/templates/nw_dualaz_multitier_natgateway.compound
+++ b/templates/nw_dualaz_multitier_natgateway.compound
@@ -307,7 +307,7 @@
                     "PeeredDc1Name" : { "Ref" : "VpcPeerDc1Name" },
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
-                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc1Ip" },
+                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }

--- a/templates/nw_singleaz_multitier_nat_with_eni.compound
+++ b/templates/nw_singleaz_multitier_nat_with_eni.compound
@@ -269,7 +269,7 @@
                     "PeeredDc1Name" : { "Ref" : "VpcPeerDc1Name" },
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
-                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc1Ip" },
+                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }

--- a/templates/nw_singleaz_multitier_natgateway.compound
+++ b/templates/nw_singleaz_multitier_natgateway.compound
@@ -233,7 +233,7 @@
                     "PeeredDc1Name" : { "Ref" : "VpcPeerDc1Name" },
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
-                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc1Ip" },
+                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }

--- a/templates/nw_tripleaz_multitier_nat_with_eni.compound
+++ b/templates/nw_tripleaz_multitier_nat_with_eni.compound
@@ -441,7 +441,7 @@
                     "PeeredDc1Name" : { "Ref" : "VpcPeerDc1Name" },
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
-                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc1Ip" },
+                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }

--- a/templates/nw_tripleaz_multitier_natgateway.compound
+++ b/templates/nw_tripleaz_multitier_natgateway.compound
@@ -381,7 +381,7 @@
                     "PeeredDc1Name" : { "Ref" : "VpcPeerDc1Name" },
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
-                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc1Ip" },
+                    "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }


### PR DESCRIPTION
PeeredDC2IP parameter to be passed to element cfn was referencing VpcPeerDc1Ip compound cfn parameter.