### PR TITLE
Group params together for NW parent templates (NATGW and NAT instances)

### DIFF
--- a/templates/nw_dualaz_multitier_nat_with_eni.compound
+++ b/templates/nw_dualaz_multitier_nat_with_eni.compound
@@ -121,6 +121,85 @@
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
         }
     },
+    "Metadata" :
+    {
+        "AWS::CloudFormation::Interface" :
+        {
+            "ParameterGroups" :
+            [
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRVPC"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Private Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPrivateSubnet1",
+                        "CIDRPrivateSubnet2"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Public Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPublicSubnet1",
+                        "CIDRPublicSubnet2"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "NAT Instances Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "InstanceTypeNAT",
+                        "KeyPairName",
+                        "IpAddressNAT1",
+                        "IpAddressNAT2"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerId",
+                        "VpcPeerCidr"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Route53 Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerDomainDnsName",
+                        "VpcPeerDc1Name",
+                        "VpcPeerDc1Ip",
+                        "VpcPeerDc2Name",
+                        "VpcPeerDc2Ip"
+                    ]
+                }
+            ]
+        }
+    },
     "Conditions" :
     {
         "PeerVpc" :

--- a/templates/nw_dualaz_multitier_natgateway.compound
+++ b/templates/nw_dualaz_multitier_natgateway.compound
@@ -92,6 +92,72 @@
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
         }
     },
+    "Metadata" :
+    {
+        "AWS::CloudFormation::Interface" :
+        {
+            "ParameterGroups" :
+            [
+                {
+                    "Label" :
+                    { 
+                        "default" : "VPC Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "CIDRVPC"
+                    ]
+                },
+                {
+                    "Label" :
+                    { 
+                        "default" : "Private Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "CIDRPrivateSubnet1",
+                        "CIDRPrivateSubnet2"
+                    ]
+                },
+                {
+                    "Label" :
+                    { 
+                        "default" : "Public Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "CIDRPublicSubnet1",
+                        "CIDRPublicSubnet2"
+                    ]
+                },
+                {
+                    "Label" :
+                    { 
+                        "default" : "VPC Peering Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "VpcPeerId",
+                        "VpcPeerCidr"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Route53 Configuration"
+                    },
+                    "Parameters" :  
+                    [
+                        "VpcPeerDomainDnsName",
+                        "VpcPeerDc1Name",
+                        "VpcPeerDc1Ip",
+                        "VpcPeerDc2Name",
+                        "VpcPeerDc2Ip"
+                    ]
+                }
+            ]
+        }
+    },
     "Conditions" :
     {
         "PeerVpc" :

--- a/templates/nw_singleaz_multitier_nat_with_eni.compound
+++ b/templates/nw_singleaz_multitier_nat_with_eni.compound
@@ -101,6 +101,82 @@
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
         }
     },
+    "Metadata" :
+    {
+        "AWS::CloudFormation::Interface" :
+        {
+            "ParameterGroups" :
+            [
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRVPC"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Private Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPrivateSubnet1"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Public Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPublicSubnet1"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "NAT Instance Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "InstanceTypeNAT",
+                        "KeyPairName",
+                        "IpAddressNAT1"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerId",
+                        "VpcPeerCidr"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Route53 Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerDomainDnsName",
+                        "VpcPeerDc1Name",
+                        "VpcPeerDc1Ip",
+                        "VpcPeerDc2Name",
+                        "VpcPeerDc2Ip"
+                    ]
+                }
+            ]
+        }
+    },
     "Conditions" :
     {
         "PeerVpc" :

--- a/templates/nw_singleaz_multitier_natgateway.compound
+++ b/templates/nw_singleaz_multitier_natgateway.compound
@@ -78,6 +78,70 @@
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
         }
     },
+    "Metadata" :
+    {
+        "AWS::CloudFormation::Interface" :
+        {
+            "ParameterGroups" :
+            [
+                {
+                    "Label" :
+                    { 
+                        "default" : "VPC Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "CIDRVPC"
+                    ]
+                },
+                {
+                    "Label" :
+                    { 
+                        "default" : "Private Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "CIDRPrivateSubnet1"
+                    ]
+                },
+                {
+                    "Label" :
+                    { 
+                        "default" : "Public Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "CIDRPublicSubnet1"
+                    ]
+                },
+                {
+                    "Label" :
+                    { 
+                        "default" : "VPC Peering Configuration"
+                    },
+                    "Parameters" :
+                    [ 
+                        "VpcPeerId",
+                        "VpcPeerCidr"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Route53 Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerDomainDnsName",
+                        "VpcPeerDc1Name",
+                        "VpcPeerDc1Ip",
+                        "VpcPeerDc2Name",
+                        "VpcPeerDc2Ip"
+                    ]
+                }
+            ]
+        }
+    },
     "Conditions" :
     {
         "PeerVpc" :

--- a/templates/nw_tripleaz_multitier_nat_with_eni.compound
+++ b/templates/nw_tripleaz_multitier_nat_with_eni.compound
@@ -141,6 +141,88 @@
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
         }
     },
+    "Metadata" :
+    {
+        "AWS::CloudFormation::Interface" :
+        {
+            "ParameterGroups" :
+            [
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRVPC"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Private Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPrivateSubnet1",
+                        "CIDRPrivateSubnet2",
+                        "CIDRPrivateSubnet3"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Public Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPublicSubnet1",
+                        "CIDRPublicSubnet2",
+                        "CIDRPublicSubnet3"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "NAT Instances Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "InstanceTypeNAT",
+                        "KeyPairName",
+                        "IpAddressNAT1",
+                        "IpAddressNAT2",
+                        "IpAddressNAT3"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerId",
+                        "VpcPeerCidr"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Route53 Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerDomainDnsName",
+                        "VpcPeerDc1Name",
+                        "VpcPeerDc1Ip",
+                        "VpcPeerDc2Name",
+                        "VpcPeerDc2Ip"
+                    ]
+                }
+            ]
+        }
+    },
     "Conditions" :
     {
         "PeerVpc" :

--- a/templates/nw_tripleaz_multitier_natgateway.compound
+++ b/templates/nw_tripleaz_multitier_natgateway.compound
@@ -106,6 +106,74 @@
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
         }
     },
+    "Metadata" :
+    {
+        "AWS::CloudFormation::Interface" :
+        {
+            "ParameterGroups" :
+            [
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRVPC"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Private Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPrivateSubnet1",
+                        "CIDRPrivateSubnet2",
+                        "CIDRPrivateSubnet3"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Public Subnet Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "CIDRPublicSubnet1",
+                        "CIDRPublicSubnet2",
+                        "CIDRPublicSubnet3"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerId",
+                        "VpcPeerCidr"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "VPC Peering Route53 Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "VpcPeerDomainDnsName",
+                        "VpcPeerDc1Name",
+                        "VpcPeerDc1Ip",
+                        "VpcPeerDc2Name",
+                        "VpcPeerDc2Ip"
+                    ]
+                }
+            ]
+        }
+    },
     "Conditions" :
     {
         "PeerVpc" :


### PR DESCRIPTION
The ones for NAT instances clean up nicely

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plus3it/cfn/75)
<!-- Reviewable:end -->
