### PR TITLE
Support optionally specifying AMI ID instead of the AMI name search

### DIFF
--- a/templates/ra_dualaz_rdgw_elb.compound
+++ b/templates/ra_dualaz_rdgw_elb.compound
@@ -129,32 +129,32 @@
             "Type" : "AWS::EC2::Subnet::Id"
         }
     },
-     "Metadata" : 
+     "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDGW Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "RdgwAmiNameSearchString",
-                        "AmiId",						
+                        "AmiId",
                         "InstanceTypeRdgw",
                         "KeyPairName"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDGW Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "DomainDNSName",
                         "DomainNetBIOSName",
                         "DomainJoinUser",
@@ -163,47 +163,47 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle"
                     ]
                 },
-                                
+
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ElbSslCertificateName",
                         "ElbSslCertificateService",
-                        "ElbPublicSubnetIDs"                        
+                        "ElbPublicSubnetIDs"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
                         "Rdgw1PrivateSubnetID",
                         "Rdgw2PrivateSubnetID"
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "RdgwAmiNameSearchString" : 
-                { 
+                "RdgwAmiNameSearchString" :
+                {
                     "default" : "RDGW AMI Search Pattern"
                 }
-            }    
+            }
         }
     },
     "Resources" :
@@ -265,7 +265,7 @@
                     "ForceUpdateToggle" : {"Ref" : "ForceUpdateToggle"},
                     "KeyPairName" : {"Ref" : "KeyPairName"},
                     "AmiNameSearchString" : {"Ref" : "RdgwAmiNameSearchString"},
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdgwInstanceType" : {"Ref" : "InstanceTypeRdgw"},
                     "RdgwElbName" :
                     {

--- a/templates/ra_dualaz_rdgw_elb.compound
+++ b/templates/ra_dualaz_rdgw_elb.compound
@@ -106,6 +106,12 @@
             "MaxLength" : "15",
             "AllowedPattern" : "[a-zA-Z0-9]+"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search ",
+            "Type" : "String",
+            "Default" : ""
+        },
         "RdgwAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -137,6 +143,7 @@
                     "Parameters" : 
                     [ 
                         "RdgwAmiNameSearchString",
+                        "AmiId"						
                         "InstanceTypeRdgw",
                         "KeyPairName"
                         ]
@@ -258,6 +265,7 @@
                     "ForceUpdateToggle" : {"Ref" : "ForceUpdateToggle"},
                     "KeyPairName" : {"Ref" : "KeyPairName"},
                     "AmiNameSearchString" : {"Ref" : "RdgwAmiNameSearchString"},
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdgwInstanceType" : {"Ref" : "InstanceTypeRdgw"},
                     "RdgwElbName" :
                     {
@@ -300,6 +308,7 @@
                     "ForceUpdateToggle" : {"Ref" : "ForceUpdateToggle"},
                     "KeyPairName" : {"Ref" : "KeyPairName"},
                     "AmiNameSearchString" : {"Ref" : "RdgwAmiNameSearchString"},
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdgwInstanceType" : {"Ref" : "InstanceTypeRdgw"},
                     "RdgwElbName" :
                     {

--- a/templates/ra_dualaz_rdgw_elb.compound
+++ b/templates/ra_dualaz_rdgw_elb.compound
@@ -143,10 +143,10 @@
                     "Parameters" : 
                     [ 
                         "RdgwAmiNameSearchString",
-                        "AmiId"						
+                        "AmiId",						
                         "InstanceTypeRdgw",
                         "KeyPairName"
-                        ]
+                    ]
                 },
                 {
                     "Label" : 

--- a/templates/ra_dualaz_rdsh_elb.compound
+++ b/templates/ra_dualaz_rdsh_elb.compound
@@ -68,6 +68,12 @@
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type" : "AWS::EC2::KeyPair::KeyName"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "RdshAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -126,6 +132,7 @@
                     "Parameters" : 
                     [ 
                         "RdshAmiNameSearchString",
+                        "AmiId",						
                         "RdshInstanceType",
                         "KeyPairName"
                     ]
@@ -230,6 +237,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -276,6 +284,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {

--- a/templates/ra_dualaz_rdsh_elb.compound
+++ b/templates/ra_dualaz_rdsh_elb.compound
@@ -73,7 +73,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "RdshAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -118,32 +118,32 @@
             "Type" : "AWS::EC2::VPC::Id"
         }
     },
-    "Metadata" : 
+    "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDSH Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "RdshAmiNameSearchString",
-                        "AmiId",						
+                        "AmiId",
                         "RdshInstanceType",
                         "KeyPairName"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDSH Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "DomainDNSName",
                         "DomainNetBIOSName",
                         "DomainJoinUser",
@@ -153,44 +153,44 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle"
                     ]
-                },                               
+                },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
-                        "ElbPrivateSubnetIDs"                        
+                    [
+                        "ElbPrivateSubnetIDs"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
                         "Rdsh1PrivateSubnetID",
-                        "Rdsh2PrivateSubnetID"                       
+                        "Rdsh2PrivateSubnetID"
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "RdshAmiNameSearchString" : 
-                { 
+                "RdshAmiNameSearchString" :
+                {
                     "default" : "RDSH AMI Search Pattern"
                 }
-            }    
+            }
         }
     },
     "Resources" :
@@ -237,7 +237,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -284,7 +284,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -315,7 +315,7 @@
                     "VPC" : { "Ref" : "VPC" }
                 }
             }
-        }      
+        }
     },
     "Outputs" :
     {

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -465,8 +465,8 @@
                     "Fn::If" :
                     [
                         "UseAmiLookup",
-                            {"Fn::GetAtt" : [ "AmiIdLookup", "Id" ]},
-                            {"Ref" : "AmiId"}
+                        {"Fn::GetAtt" : [ "AmiIdLookup", "Id" ]},
+                        {"Ref" : "AmiId"}
                     ]
                 },
                 "InstanceType" : { "Ref" : "InstanceType" },

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -13,7 +13,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "AmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -163,7 +163,7 @@
         "AmiIdLookup":
         {
             "Type": "Custom::AmiIdLookup",
-            "Condition" : "NotToUseAmiId",			
+            "Condition" : "NotToUseAmiId",
             "Properties":
             {
                 "ServiceToken":

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -8,6 +8,12 @@
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type" : "AWS::EC2::KeyPair::KeyName"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "AmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -142,13 +148,22 @@
         "UseURLText2" :
         {
             "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "URLText2" }, "" ] } ]
-        }
+        },
+        "UseAmiId" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] } ]
+        },
+        "NotToUseAmiId" :
+        {
+              "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] 
+        }		
     },
     "Resources" :
     {
         "AmiIdLookup":
         {
             "Type": "Custom::AmiIdLookup",
+            "Condition" : "NotToUseAmiId",			
             "Properties":
             {
                 "ServiceToken":
@@ -449,7 +464,12 @@
             },
             "Properties" :
             {
-                "ImageId": { "Fn::GetAtt": [ "AmiIdLookup", "Id" ] },
+                "ImageId" : {
+                    "Fn::If" : [
+                               "UseAmiId",
+                               {"Ref" : "AmiId"},
+                               {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]}
+                               ]},
                 "InstanceType" : { "Ref" : "InstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_guac_private_autoscale_elb.element
+++ b/templates/ra_guac_private_autoscale_elb.element
@@ -149,21 +149,17 @@
         {
             "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "URLText2" }, "" ] } ]
         },
-        "UseAmiId" :
+        "UseAmiLookup" :
         {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] } ]
-        },
-        "NotToUseAmiId" :
-        {
-              "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] 
-        }		
+            "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ]
+        }
     },
     "Resources" :
     {
         "AmiIdLookup":
         {
             "Type": "Custom::AmiIdLookup",
-            "Condition" : "NotToUseAmiId",
+            "Condition" : "UseAmiLookup",
             "Properties":
             {
                 "ServiceToken":
@@ -464,12 +460,15 @@
             },
             "Properties" :
             {
-                "ImageId" : {
-                    "Fn::If" : [
-                               "UseAmiId",
-                               {"Ref" : "AmiId"},
-                               {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]}
-                               ]},
+                "ImageId" :
+                {
+                    "Fn::If" :
+                    [
+                        "UseAmiLookup",
+                            {"Fn::GetAtt" : [ "AmiIdLookup", "Id" ]},
+                            {"Ref" : "AmiId"}
+                    ]
+                },
                 "InstanceType" : { "Ref" : "InstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_multiaz_guac_elb.compound
+++ b/templates/ra_multiaz_guac_elb.compound
@@ -71,7 +71,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "GuacAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -145,32 +145,32 @@
             "Type" : "List<AWS::EC2::Subnet::Id>"
         }
     },
-    "Metadata" : 
+    "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "Guac Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "GuacAmiNameSearchString",
-                        "AmiId",						
+                        "AmiId",
                         "InstanceType",
                         "KeyPairName"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "Guac Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "GuacLdapServer",
                         "GuacLdapDN",
                         "GuacVersion",
@@ -181,12 +181,12 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle",
                         "DesiredCapacity",
                         "MinCapacity",
@@ -194,32 +194,32 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "SslCertificateName",
                         "SslCertificateService"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
                         "PrivateSubnetIDs",
                         "PublicSubnetIDs"
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "GuacAmiNameSearchString" : 
-                { 
+                "GuacAmiNameSearchString" :
+                {
                     "default" : "Guac AMI Search Pattern"
                 }
             }
@@ -282,7 +282,7 @@
                     "ForceUpdateToggle" : {"Ref" : "ForceUpdateToggle"},
                     "KeyPairName" : {"Ref" : "KeyPairName"},
                     "AmiNameSearchString" : {"Ref" : "GuacAmiNameSearchString"},
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "InstanceType" : {"Ref" : "InstanceType"},
                     "MinCapacity" : {"Ref" : "MinCapacity"},
                     "MaxCapacity" : {"Ref" : "MaxCapacity"},

--- a/templates/ra_multiaz_guac_elb.compound
+++ b/templates/ra_multiaz_guac_elb.compound
@@ -66,7 +66,7 @@
             "MinLength" : "1",
             "Default" : "1"
         },
-         "AmiId" :
+        "AmiId" :
         {
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
@@ -162,7 +162,7 @@
                         "AmiId",						
                         "InstanceType",
                         "KeyPairName"
-                        ]
+                    ]
                 },
                 {
                     "Label" : 

--- a/templates/ra_multiaz_guac_elb.compound
+++ b/templates/ra_multiaz_guac_elb.compound
@@ -66,6 +66,12 @@
             "MinLength" : "1",
             "Default" : "1"
         },
+         "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "GuacAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -153,6 +159,7 @@
                     "Parameters" : 
                     [ 
                         "GuacAmiNameSearchString",
+                        "AmiId",						
                         "InstanceType",
                         "KeyPairName"
                         ]
@@ -275,6 +282,7 @@
                     "ForceUpdateToggle" : {"Ref" : "ForceUpdateToggle"},
                     "KeyPairName" : {"Ref" : "KeyPairName"},
                     "AmiNameSearchString" : {"Ref" : "GuacAmiNameSearchString"},
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "InstanceType" : {"Ref" : "InstanceType"},
                     "MinCapacity" : {"Ref" : "MinCapacity"},
                     "MaxCapacity" : {"Ref" : "MaxCapacity"},

--- a/templates/ra_rdgw_private_autoscale_elb.element
+++ b/templates/ra_rdgw_private_autoscale_elb.element
@@ -336,10 +336,10 @@
                     "Fn::If" :
                     [
                         "UseAmiId",
-                            {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]},
-                            {"Ref" : "AmiId"}
+                        {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]},
+                        {"Ref" : "AmiId"}
                     ]
-				},
+                },
                 "InstanceType" : { "Ref" : "RdgwInstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_rdgw_private_autoscale_elb.element
+++ b/templates/ra_rdgw_private_autoscale_elb.element
@@ -116,21 +116,17 @@
     },
     "Conditions" :
     {
-        "UseAmiId" :
+        "UseAmiLookup" :
         {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] } ]
-        },
-        "NotToUseAmiId" :
-        {
-              "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] 
-        }		
+            "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ]
+        }
     },
     "Resources" :
     {
         "AmiIdLookup" :
         {
             "Type" : "Custom::AmiIdLookup",
-            "Condition" : "NotToUseAmiId",			
+            "Condition" : "UseAmiLookup",			
             "Properties" :
             {
                 "ServiceToken" :
@@ -335,12 +331,15 @@
             },
             "Properties" :
             {
-                "ImageId" : {
-                    "Fn::If" : [
-                               "UseAmiId",
-                               {"Ref" : "AmiId"},
-                               {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]}
-                               ]},
+                "ImageId" :
+                {
+                    "Fn::If" :
+                    [
+                        "UseAmiId",
+                            {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]},
+                            {"Ref" : "AmiId"}
+                    ]
+				},
                 "InstanceType" : { "Ref" : "RdgwInstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_rdgw_private_autoscale_elb.element
+++ b/templates/ra_rdgw_private_autoscale_elb.element
@@ -13,7 +13,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "ForceUpdateToggle" :
         {
             "Description" : "A/B toggle that forces a change to a LaunchConfig property, triggering the AutoScale Update Policy",
@@ -126,7 +126,7 @@
         "AmiIdLookup" :
         {
             "Type" : "Custom::AmiIdLookup",
-            "Condition" : "UseAmiLookup",			
+            "Condition" : "UseAmiLookup",
             "Properties" :
             {
                 "ServiceToken" :

--- a/templates/ra_rdgw_private_autoscale_elb.element
+++ b/templates/ra_rdgw_private_autoscale_elb.element
@@ -8,6 +8,12 @@
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type" : "AWS::EC2::KeyPair::KeyName"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "ForceUpdateToggle" :
         {
             "Description" : "A/B toggle that forces a change to a LaunchConfig property, triggering the AutoScale Update Policy",
@@ -108,11 +114,23 @@
             "Type" : "AWS::EC2::VPC::Id"
         }
     },
+    "Conditions" :
+    {
+        "UseAmiId" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] } ]
+        },
+        "NotToUseAmiId" :
+        {
+              "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] 
+        }		
+    },
     "Resources" :
     {
         "AmiIdLookup" :
         {
             "Type" : "Custom::AmiIdLookup",
+            "Condition" : "NotToUseAmiId",			
             "Properties" :
             {
                 "ServiceToken" :
@@ -317,7 +335,12 @@
             },
             "Properties" :
             {
-                "ImageId" : { "Fn::GetAtt" : [ "AmiIdLookup", "Id" ] },
+                "ImageId" : {
+                    "Fn::If" : [
+                               "UseAmiId",
+                               {"Ref" : "AmiId"},
+                               {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]}
+                               ]},
                 "InstanceType" : { "Ref" : "RdgwInstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_rdsh_private_autoscale_elb.element
+++ b/templates/ra_rdsh_private_autoscale_elb.element
@@ -8,6 +8,12 @@
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type" : "AWS::EC2::KeyPair::KeyName"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "ForceUpdateToggle" :
         {
             "Description" : "A/B toggle that forces a change to a LaunchConfig property, triggering the AutoScale Update Policy",
@@ -115,11 +121,23 @@
             "Type" : "AWS::EC2::VPC::Id"
         }
     },
+    "Conditions" :
+    {
+        "UseAmiId" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] } ]
+        },
+        "NotToUseAmiId" :
+        {
+              "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] 
+        }		
+    },	
     "Resources" :
     {
         "AmiIdLookup" :
         {
             "Type" : "Custom::AmiIdLookup",
+            "Condition" : "NotToUseAmiId",			
             "Properties" :
             {
                 "ServiceToken" :
@@ -331,7 +349,12 @@
             },
             "Properties" :
             {
-                "ImageId" : { "Fn::GetAtt" : [ "AmiIdLookup", "Id" ] },
+                "ImageId" : {
+                    "Fn::If" : [
+                               "UseAmiId",
+                               {"Ref" : "AmiId"},
+                               {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]}
+                               ]},
                 "InstanceType" : { "Ref" : "RdshInstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_rdsh_private_autoscale_elb.element
+++ b/templates/ra_rdsh_private_autoscale_elb.element
@@ -123,21 +123,17 @@
     },
     "Conditions" :
     {
-        "UseAmiId" :
+        "UseAmiLookup" :
         {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] } ]
-        },
-        "NotToUseAmiId" :
-        {
-              "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ] 
-        }		
-    },	
+            "Fn::Equals" : [ { "Ref" : "AmiId" }, "" ]
+        }
+    },
     "Resources" :
     {
         "AmiIdLookup" :
         {
             "Type" : "Custom::AmiIdLookup",
-            "Condition" : "NotToUseAmiId",			
+            "Condition" : "UseAmiLookup",			
             "Properties" :
             {
                 "ServiceToken" :
@@ -349,12 +345,15 @@
             },
             "Properties" :
             {
-                "ImageId" : {
-                    "Fn::If" : [
-                               "UseAmiId",
-                               {"Ref" : "AmiId"},
-                               {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]}
-                               ]},
+                "ImageId" :
+                {
+                    "Fn::If" :
+                    [
+                        "UseAmiId",
+                            {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]},
+                            {"Ref" : "AmiId"}
+                    ]
+                },
                 "InstanceType" : { "Ref" : "RdshInstanceType" },
                 "KeyName" : { "Ref" : "KeyPairName" },
                 "BlockDeviceMappings" :

--- a/templates/ra_rdsh_private_autoscale_elb.element
+++ b/templates/ra_rdsh_private_autoscale_elb.element
@@ -350,8 +350,8 @@
                     "Fn::If" :
                     [
                         "UseAmiId",
-                            {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]},
-                            {"Ref" : "AmiId"}
+                        {"Fn::GetAtt": [ "AmiIdLookup", "Id" ]},
+                        {"Ref" : "AmiId"}
                     ]
                 },
                 "InstanceType" : { "Ref" : "RdshInstanceType" },

--- a/templates/ra_rdsh_private_autoscale_elb.element
+++ b/templates/ra_rdsh_private_autoscale_elb.element
@@ -13,7 +13,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "ForceUpdateToggle" :
         {
             "Description" : "A/B toggle that forces a change to a LaunchConfig property, triggering the AutoScale Update Policy",
@@ -133,7 +133,7 @@
         "AmiIdLookup" :
         {
             "Type" : "Custom::AmiIdLookup",
-            "Condition" : "UseAmiLookup",			
+            "Condition" : "UseAmiLookup",
             "Properties" :
             {
                 "ServiceToken" :

--- a/templates/ra_singleaz_rdgw_elb.compound
+++ b/templates/ra_singleaz_rdgw_elb.compound
@@ -141,7 +141,7 @@
                         "AmiId",						
                         "InstanceTypeRdgw",
                         "KeyPairName"
-                        ]
+                    ]
                 },
                 {
                     "Label" : 

--- a/templates/ra_singleaz_rdgw_elb.compound
+++ b/templates/ra_singleaz_rdgw_elb.compound
@@ -106,6 +106,12 @@
             "MaxLength" : "15",
             "AllowedPattern" : "[a-zA-Z0-9]+"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "RdgwAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -132,6 +138,7 @@
                     "Parameters" : 
                     [ 
                         "RdgwAmiNameSearchString",
+                        "AmiId",						
                         "InstanceTypeRdgw",
                         "KeyPairName"
                         ]
@@ -251,6 +258,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {

--- a/templates/ra_singleaz_rdgw_elb.compound
+++ b/templates/ra_singleaz_rdgw_elb.compound
@@ -111,7 +111,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "RdgwAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -124,32 +124,32 @@
             "Type" : "AWS::EC2::Subnet::Id"
         }
     },
-     "Metadata" : 
+     "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDGW Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "RdgwAmiNameSearchString",
-                        "AmiId",						
+                        "AmiId",
                         "InstanceTypeRdgw",
                         "KeyPairName"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDGW Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "DomainDNSName",
                         "DomainNetBIOSName",
                         "DomainJoinUser",
@@ -158,45 +158,45 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ElbSslCertificateName",
                         "ElbSslCertificateService",
-                        "ElbPublicSubnetIDs"                        
+                        "ElbPublicSubnetIDs"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
-                        "Rdgw1PrivateSubnetID"                       
+                        "Rdgw1PrivateSubnetID"
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "RdgwAmiNameSearchString" : 
-                { 
+                "RdgwAmiNameSearchString" :
+                {
                     "default" : "RDGW AMI Search Pattern"
                 }
-            }    
+            }
         }
     },
     "Resources" :
@@ -258,7 +258,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {

--- a/templates/ra_singleaz_rdsh_elb.compound
+++ b/templates/ra_singleaz_rdsh_elb.compound
@@ -73,7 +73,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "RdshAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -114,32 +114,32 @@
             "Type" : "AWS::EC2::VPC::Id"
         }
     },
-    "Metadata" : 
+    "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDSH Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "RdshAmiNameSearchString",
-                        "AmiId",				
+                        "AmiId",
                         "RdshInstanceType",
                         "KeyPairName"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDSH Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "DomainDNSName",
                         "DomainNetBIOSName",
                         "DomainJoinUser",
@@ -149,43 +149,43 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle"
                     ]
-                },                               
+                },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
-                        "ElbPrivateSubnetIDs"                        
+                    [
+                        "ElbPrivateSubnetIDs"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
-                        "Rdsh1PrivateSubnetID"                        
+                        "Rdsh1PrivateSubnetID"
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "RdshAmiNameSearchString" : 
-                { 
+                "RdshAmiNameSearchString" :
+                {
                     "default" : "RDSH AMI Search Pattern"
                 }
-            }    
+            }
         }
     },
     "Resources" :
@@ -242,7 +242,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {

--- a/templates/ra_singleaz_rdsh_elb.compound
+++ b/templates/ra_singleaz_rdsh_elb.compound
@@ -68,6 +68,12 @@
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type" : "AWS::EC2::KeyPair::KeyName"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "RdshAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -122,6 +128,7 @@
                     "Parameters" : 
                     [ 
                         "RdshAmiNameSearchString",
+                        "AmiId",				
                         "RdshInstanceType",
                         "KeyPairName"
                     ]
@@ -235,6 +242,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {

--- a/templates/ra_tripleaz_rdgw_elb.compound
+++ b/templates/ra_tripleaz_rdgw_elb.compound
@@ -106,6 +106,12 @@
             "MaxLength" : "15",
             "AllowedPattern" : "[a-zA-Z0-9]+"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "RdgwAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -142,6 +148,7 @@
                     "Parameters" : 
                     [ 
                         "RdgwAmiNameSearchString",
+                        "AmiId",					
                         "InstanceTypeRdgw",
                         "KeyPairName"
                         ]
@@ -263,6 +270,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {
@@ -308,6 +316,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {
@@ -353,6 +362,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {

--- a/templates/ra_tripleaz_rdgw_elb.compound
+++ b/templates/ra_tripleaz_rdgw_elb.compound
@@ -111,7 +111,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "RdgwAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -134,32 +134,32 @@
             "Type" : "AWS::EC2::Subnet::Id"
         }
     },
-    "Metadata" : 
+    "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDGW Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "RdgwAmiNameSearchString",
-                        "AmiId",					
+                        "AmiId",
                         "InstanceTypeRdgw",
                         "KeyPairName"
                         ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDGW Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "DomainDNSName",
                         "DomainNetBIOSName",
                         "DomainJoinUser",
@@ -168,33 +168,33 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle"
                     ]
-                },                               
+                },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ElbSslCertificateName",
                         "ElbSslCertificateService",
-                        "ElbPublicSubnetIDs"                        
+                        "ElbPublicSubnetIDs"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
                         "Rdgw1PrivateSubnetID",
                         "Rdgw2PrivateSubnetID",
@@ -202,13 +202,13 @@
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "RdgwAmiNameSearchString" : 
-                { 
+                "RdgwAmiNameSearchString" :
+                {
                     "default" : "RDGW AMI Search Pattern"
                 }
-            }    
+            }
         }
     },
     "Resources" :
@@ -270,7 +270,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {
@@ -316,7 +316,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {
@@ -362,7 +362,7 @@
                     {
                         "Ref" : "RdgwAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdgwInstanceType" : { "Ref" : "InstanceTypeRdgw" },
                     "RdgwElbName" :
                     {

--- a/templates/ra_tripleaz_rdsh_elb.compound
+++ b/templates/ra_tripleaz_rdsh_elb.compound
@@ -68,6 +68,12 @@
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type" : "AWS::EC2::KeyPair::KeyName"
         },
+        "AmiId" :
+        {
+            "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
+            "Type" : "String",
+            "Default" : ""
+        },		
         "RdshAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -236,6 +242,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -282,6 +289,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -328,6 +336,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
+                    "AmiId" : {"Ref" : "AmiId"},					
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {

--- a/templates/ra_tripleaz_rdsh_elb.compound
+++ b/templates/ra_tripleaz_rdsh_elb.compound
@@ -73,7 +73,7 @@
             "Description" : "AMI Name --Optional-- Will supersede Lambda Search",
             "Type" : "String",
             "Default" : ""
-        },		
+        },
         "RdshAmiNameSearchString" :
         {
             "Description" : "Search pattern to match against an AMI Name",
@@ -123,31 +123,31 @@
             "Type" : "AWS::EC2::VPC::Id"
         }
     },
-    "Metadata" : 
+    "Metadata" :
     {
-        "AWS::CloudFormation::Interface" : 
+        "AWS::CloudFormation::Interface" :
         {
-            "ParameterGroups" : 
+            "ParameterGroups" :
             [
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDSH Instance Configuration"
                     },
-                    "Parameters" : 
-                    [ 
+                    "Parameters" :
+                    [
                         "RdshAmiNameSearchString",
                         "RdshInstanceType",
                         "KeyPairName"
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "RDSH Application Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "DomainDNSName",
                         "DomainNetBIOSName",
                         "DomainJoinUser",
@@ -157,31 +157,31 @@
                     ]
                 },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "AutoScale Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "ForceUpdateToggle"
                     ]
-                },                               
+                },
                 {
-                    "Label" : 
-                    { 
+                    "Label" :
+                    {
                         "default" : "ELB Configuration"
                     },
                     "Parameters" :
-                    [ 
-                        "ElbPrivateSubnetIDs"                        
+                    [
+                        "ElbPrivateSubnetIDs"
                     ]
-                },        
+                },
                 {   "Label" :
-                    { 
+                    {
                         "default" : "Network Configuration"
                     },
                     "Parameters" :
-                    [ 
+                    [
                         "VPC",
                         "Rdsh1PrivateSubnetID",
                         "Rdsh2PrivateSubnetID",
@@ -189,13 +189,13 @@
                     ]
                 }
             ],
-            "ParameterLabels" : 
+            "ParameterLabels" :
             {
-                "RdshAmiNameSearchString" : 
-                { 
+                "RdshAmiNameSearchString" :
+                {
                     "default" : "RDSH AMI Search Pattern"
                 }
-            }    
+            }
         }
     },
     "Resources" :
@@ -242,7 +242,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -289,7 +289,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {
@@ -336,7 +336,7 @@
                     {
                         "Ref" : "RdshAmiNameSearchString"
                     },
-                    "AmiId" : {"Ref" : "AmiId"},					
+                    "AmiId" : {"Ref" : "AmiId"},
                     "RdshInstanceType" : { "Ref" : "RdshInstanceType" },
                     "RdshElbName" :
                     {


### PR DESCRIPTION
* Added AmiId parameter to the guac, rdsh, and rdgw compound and the autoscale_elb.element templates. Also added in the parameter section of the autoscale nested template in the compound temnplate.
* Added the UseAmiLookup condition to the autoscale templates of the three components to test whether to use the AmiId for image. If blank the result from the lambda function will be used for the AMI.
* A condition statement was added in the lambda resource section so that if the AmiId parameter is entered the resource is ignored.
* In the Launch Config section a test of the UseAmiLookup was added. If true the AMI ID returned by the custom lambda function will be used, else the AmiId parameter will be used.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plus3it/cfn/79)
<!-- Reviewable:end -->
