### PR TITLE
Installation of Non-MSI Installers

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -110,5 +110,8 @@ $ExeInstaller = "${Env:Temp}\AtomSetup.exe"
 $ExeParams = "--silent"
 $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
 
+# Install PsGet, a PowerShell Module
+(new-object Net.WebClient).DownloadString("http://psget.net/GetPsGet.ps1") | iex
+
 # Restart
 Restart-Computer -Force

--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -96,5 +96,12 @@ $ExeInstaller = "${Env:Temp}\Git-2.10.1-64-bit.exe"
 $ExeParams = "/SILENT /NOCANCEL /NORESTART /SAVEINF=${Env:Temp}\git_params.txt"
 $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
 
+# Install Python 3.5
+$ExeUrl = "https://www.python.org/ftp/python/3.5.2/python-3.5.2-amd64.exe"
+$ExeInstaller = "${Env:Temp}\python-3.5.2-amd64.exe"
+(new-object net.webclient).DownloadFile("${ExeUrl}","${ExeInstaller}")
+$ExeParams = "/quiet"
+$null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
+
 # Restart
 Restart-Computer -Force

--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -113,5 +113,12 @@ $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -Pass
 # Install PsGet, a PowerShell Module
 (new-object Net.WebClient).DownloadString("http://psget.net/GetPsGet.ps1") | iex
 
+# Install Visual C++ Build Tools 2015
+$ExeUrl = "http://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe"
+$ExeInstaller = "${Env:Temp}\visualcppbuildtools_full.exe"
+(new-object net.webclient).DownloadFile("${ExeUrl}","${ExeInstaller}")
+$ExeParams = "/Full /Q /S /NoRestart /L ${env:temp}\vcpp.log"
+$null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
+
 # Restart
 Restart-Computer -Force

--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -100,7 +100,7 @@ $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -Pass
 $ExeUrl = "https://www.python.org/ftp/python/3.5.2/python-3.5.2-amd64.exe"
 $ExeInstaller = "${Env:Temp}\python-3.5.2-amd64.exe"
 (new-object net.webclient).DownloadFile("${ExeUrl}","${ExeInstaller}")
-$ExeParams = "/quiet"
+$ExeParams = "/quiet /log ${env:temp}\python.log"
 $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
 
 # Install Atom

--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -89,5 +89,12 @@ $SignOffShortcut.Description = "Sign Out"
 $SignOffShortcut.IconLocation = "${env:SYSTEMROOT}\System32\imageres.dll,81"
 $SignOffShortcut.Save()
 
+# Install Git for Windows
+$ExeUrl = "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/Git-2.10.1-64-bit.exe"
+$ExeInstaller = "${Env:Temp}\Git-2.10.1-64-bit.exe"
+(new-object net.webclient).DownloadFile("${ExeUrl}","${ExeInstaller}")
+$ExeParams = "/SILENT /NOCANCEL /NORESTART /SAVEINF=${Env:Temp}\git_params.txt"
+$null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
+
 # Restart
 Restart-Computer -Force

--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -103,5 +103,12 @@ $ExeInstaller = "${Env:Temp}\python-3.5.2-amd64.exe"
 $ExeParams = "/quiet"
 $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
 
+# Install Atom
+$ExeUrl = "https://atom.io/download/windows"
+$ExeInstaller = "${Env:Temp}\AtomSetup.exe"
+(new-object net.webclient).DownloadFile("${ExeUrl}","${ExeInstaller}")
+$ExeParams = "--silent"
+$null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
+
 # Restart
 Restart-Computer -Force


### PR DESCRIPTION
configure-rdsh.ps1 will install the following: Git for Windows, Python 3.5.2, Atom, PsGet (a PowerShell module) and Visual C++ Build Tools 2015.  Note that the parameters can be quite different from one executable installer to the next.  Parameters are logged for Git for Windows.  The installation process are logged for Python and the Build Tools.