### PR TITLE
Removes install of vcpp

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -106,12 +106,5 @@ $null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -Pass
 # Install PsGet, a PowerShell Module
 (new-object Net.WebClient).DownloadString("http://psget.net/GetPsGet.ps1") | iex
 
-# Install Visual C++ Build Tools 2015
-$ExeUrl = "http://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe"
-$ExeInstaller = "${Env:Temp}\visualcppbuildtools_full.exe"
-(new-object net.webclient).DownloadFile("${ExeUrl}","${ExeInstaller}")
-$ExeParams = "/Full /Q /S /NoRestart /L ${env:temp}\vcpp.log"
-$null = Start-Process -FilePath ${ExeInstaller} -ArgumentList ${ExeParams} -PassThru -Wait
-
 # Restart
 Restart-Computer -Force


### PR DESCRIPTION
VC++ 2015 Build Tools were intended to help with python pip-based
installs for Python 3.5, but the installer is not very robust and
was failing intermittently without explanation. Users can attempt
to install it per-user instead, if they need it.