### PR TITLE
Enables cross account VPC peering connection

### DIFF
--- a/templates/nw_create_peer_role.element
+++ b/templates/nw_create_peer_role.element
@@ -1,0 +1,65 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description" : "Create an assumable role for cross account VPC peering.",
+    "Parameters" :
+    {
+        "PeerRequesterAccountId" :
+        {
+            "Description" : "Account ID of account that will be requesting the VPC peering connection. To specify multiple accounts use \",\" as separator (Example: 123456789012,012345678901).",
+            "Type" : "List<Number>"
+        }
+    },
+    "Resources" :
+    {
+    "PeerRole" :
+        {
+            "Type" : "AWS::IAM::Role",
+            "Properties" :
+            {
+                "AssumeRolePolicyDocument" :
+                {
+                    "Statement" :
+                    [
+                        {
+                            "Principal" :
+                            {
+                            "AWS" : { "Ref": "PeerRequesterAccountId" }
+                            },
+                            "Action" : [ "sts:AssumeRole" ],
+                            "Effect" : "Allow"
+                        }
+                    ]
+                },
+                "Path" : "/",
+                "Policies" :
+                [
+                    {
+                        "PolicyName" : "VPCPeer-Policy",
+                        "PolicyDocument" :
+                        {
+                            "Version" : "2012-10-17",
+                            "Statement" :
+                            [
+                                {
+                                "Effect" : "Allow",
+                                "Action" : "ec2:AcceptVpcPeeringConnection",
+                                "Resource" : "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "Outputs" :
+    {
+        "RoleARN" :
+        {
+            "Value" :
+            {
+                "Fn::GetAtt" : [ "PeerRole","Arn" ]
+            }
+        }
+    }
+}

--- a/templates/nw_peered_sg.element
+++ b/templates/nw_peered_sg.element
@@ -1,0 +1,70 @@
+{
+    "AWSTemplateFormatVersion" : "2010-09-09",
+    "Description" : "This element creates a Security Group to allow remote access from instances in the specified security group within the peered account.",
+    "Parameters"  :
+    {
+        "VPC" :
+        {
+            "Description" : "VPC ID that will contain the security group",
+            "Type" : "AWS::EC2::VPC::Id"
+        },
+        "SourcePeerIngress" :
+        {
+            "Description" : "Creates a Security Group and ingress rule to allow remote access from instances in the specified security group within the peered account (Example: sg-12345678).",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^sg-[0-9a-z]{8}$"
+        }     
+    },
+    "Resources" :
+    {
+        "AllowPeerSecurityGroup" :
+        {
+            "Type" : "AWS::EC2::SecurityGroup",
+            "Properties" :
+            {
+                "GroupDescription" : "Enables remote access from instances in the specified security group within the peered account",
+                "VpcId" : { "Ref" : "VPC" },
+                "Tags" :
+                [
+                    {
+                        "Key" : "Name",
+                        "Value" : { "Ref" : "AWS::StackName" }
+                    }
+                ]
+            }
+        },
+        "SSHIngressTcp22" :
+        {
+            "Type" : "AWS::EC2::SecurityGroupIngress",
+            "Properties" :
+            {
+                "GroupId" :  { "Ref": "AllowPeerSecurityGroup" },
+                "IpProtocol" : "tcp",
+                "FromPort" : "22",
+                "ToPort" : "22",
+                "SourceSecurityGroupId" : { "Ref": "SourcePeerIngress" }
+            }
+        },
+        "RDPIngressTcp3389" :
+        {
+            "Type" : "AWS::EC2::SecurityGroupIngress",
+            "Properties" :
+            {
+                "GroupId" :  { "Ref": "AllowPeerSecurityGroup" },
+                "IpProtocol" : "tcp",
+                "FromPort" : "3389",
+                "ToPort" : "3389",
+                "SourceSecurityGroupId" : { "Ref": "SourcePeerIngress" }
+            }
+        }
+    },    
+    "Outputs" :
+    {
+        "AllowPeerSecurityGroupId" :
+        {
+            "Value" : { "Ref" : "AllowPeerSecurityGroup" },
+            "Description" : "Security Group ID that allows remote access from instances in the specified security group within the peered account"
+        }
+    }
+}

--- a/templates/nw_tripleaz_multitier_natgateway.compound
+++ b/templates/nw_tripleaz_multitier_natgateway.compound
@@ -66,6 +66,20 @@
             "Default" : "10.0.0.0/16",
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
         },
+        "VpcPeerAccountId" :
+        {
+            "Description" : "Account ID of the cross-account peer.",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^[0-9]{12}$"
+        },
+        "VpcPeerRoleArn" :
+        {
+            "Description" : "Role ARN of the cross-account role allowing another account to achieve peering.",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^arn:aws:iam::[0-9]{12}:role\\/[a-zA-Z0-9\\-]+"
+        },
         "VpcPeerDomainDnsName" :
         {
             "Description" : "DNS name of the peered zone (Example: ad.example.com). Creates a Route53 Private Hosted Zone. Leave blank to skip this step.",
@@ -104,6 +118,13 @@
             "Type" : "String",
             "Default" : "10.0.64.10",
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+        },
+        "AllowPeerSecurityGroup" :
+        {
+            "Description" : "Creates a Security Group and ingress rule to allow remote access from instances in the specified security group within the peered account. Enter the SG from the peered account (Example: sg-12345678).",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^sg-[0-9a-z]{8}$"
         }
     },
     "Metadata" :
@@ -154,7 +175,9 @@
                     "Parameters" :
                     [
                         "VpcPeerId",
-                        "VpcPeerCidr"
+                        "VpcPeerCidr",
+                        "VpcPeerAccountId",
+                        "VpcPeerRoleArn"
                     ]
                 },
                 {
@@ -169,6 +192,16 @@
                         "VpcPeerDc1Ip",
                         "VpcPeerDc2Name",
                         "VpcPeerDc2Ip"
+                    ]
+                },
+                {
+                    "Label" :
+                    {
+                        "default" : "Allow Peered Security Group Configuration"
+                    },
+                    "Parameters" :
+                    [
+                        "AllowPeerSecurityGroup"
                     ]
                 }
             ]
@@ -186,6 +219,10 @@
             [
                 { "Fn::Equals" : [ { "Ref" : "VpcPeerDomainDnsName" }, "" ] }
             ]
+        },
+        "CreateSecurityGroup" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AllowPeerSecurityGroup" }, "" ] } ]
         }
     },
     "Resources" :
@@ -431,7 +468,9 @@
                     },
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] },
                     "VpcPeerId" : { "Ref" : "VpcPeerId" },
-                    "VpcPeerCidr" : { "Ref" : "VpcPeerCidr" }
+                    "VpcPeerCidr" : { "Ref" : "VpcPeerCidr" },
+                    "VpcPeerAccountId" : { "Ref" : "VpcPeerAccountId" },
+                    "VpcPeerRoleArn" : { "Ref" : "VpcPeerRoleArn" }
                 }
             }
         },
@@ -450,6 +489,21 @@
                     "PeeredDc1Ip" : { "Ref" : "VpcPeerDc1Ip" },
                     "PeeredDc2Name" : { "Ref" : "VpcPeerDc2Name" },
                     "PeeredDc2Ip" : { "Ref" : "VpcPeerDc2Ip" },
+                    "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
+                }
+            }
+        },
+        "PeeredSecurityGroupStack" :
+        {
+            "Type" : "AWS::CloudFormation::Stack",
+            "Condition" : "CreateSecurityGroup",
+            "DependsOn" : "VpcPeeringConnectionStack",
+            "Properties" :
+            {
+                "TemplateURL" : "https://s3.amazonaws.com/app-chemistry/templates/nw_peered_sg.element",
+                "Parameters" :
+                {
+                    "SourcePeerIngress" : { "Ref" : "AllowPeerSecurityGroup"},
                     "VPC" : { "Fn::GetAtt" : [ "VPCStack", "Outputs.VPC" ] }
                 }
             }
@@ -581,7 +635,7 @@
             {
                 "Fn::GetAtt" :
                 [
-                    "VPCStack",
+                    "VpcPeeringConnectionStack",
                     "Outputs.VpcPeeringConnection"
                 ]
             },
@@ -599,6 +653,19 @@
                 ]
             },
             "Description" : "ID of the Private Hosted Zone used for resolution of a domain in the peered VPC"
+        },
+        "AllowPeerSecurityGroup" :
+        {
+            "Condition" : "CreateSecurityGroup",
+            "Value" :
+            {
+                "Fn::GetAtt" :
+                [
+                    "PeeredSecurityGroupStack",
+                    "Outputs.AllowPeerSecurityGroupId"
+                ]
+            },
+            "Description" : "ID of the Security Group that allows remote access from instances in the specified security group within the peered account"
         }
     }
 }

--- a/templates/nw_vpc_peering_connection.element
+++ b/templates/nw_vpc_peering_connection.element
@@ -26,7 +26,7 @@
         },
         "RouteTableId4" :
         {
-            "Description" : "ID of the third Route Table that needs a route to the peered VPC. Leave blank to skip this step.",
+            "Description" : "ID of the fourth Route Table that needs a route to the peered VPC. Leave blank to skip this step.",
             "Type" : "String",
             "Default" : "",
             "AllowedPattern" : "^$|^rtb-[0-9a-z]{8}$"
@@ -49,8 +49,21 @@
             "Type" : "String",
             "Default" : "10.0.0.0/16",
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+        },
+        "VpcPeerAccountId" :
+        {
+            "Description" : "Account ID of the cross-account peer.",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^[0-9]{12}$"
+        },
+        "VpcPeerRoleArn" :
+        {
+            "Description" : "Role ARN of the cross-account role allowing another account to achieve peering.",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^arn:aws:iam::[0-9]{12}:role\\/[a-zA-Z0-9\\-]+"
         }
-        
     },
     "Conditions" :
     {
@@ -91,7 +104,9 @@
             "Properties" :
             {
                 "VpcId" : { "Ref" : "VPC" },
-                "PeerVpcId" : { "Ref": "VpcPeerId" },
+                "PeerVpcId" : { "Ref" : "VpcPeerId" },
+                "PeerOwnerId" : { "Ref" : "VpcPeerAccountId" },
+                "PeerRoleArn" : { "Ref" : "VpcPeerRoleArn" },
                 "Tags" :
                 [
                     {


### PR DESCRIPTION
- Adds template to create assumed role for cross account peering on parent account
- Adds template to create security group to allow remote access from RDSH hosts from parent account
- Updates VPC peering connection child template to allow for cross account peering
- Updates VPC TripleAZ parent template