### PR TITLE
Uses null instead of $null in Set-DnsSearchSuffix

### DIFF
--- a/scripts/set-dnssearchsuffix.ps1
+++ b/scripts/set-dnssearchsuffix.ps1
@@ -4,11 +4,11 @@ param(
     [string[]] $DnsSearchSuffixes
     ,
     [Parameter(Mandatory=$false,ValueFromPipeLine=$false,ValueFromPipeLineByPropertyName=$false)]
-    [ValidateSet($true,$false,$null)]
-    $Ec2ConfigSetDnsSuffixList = $null
+    [ValidateSet($true,$false,"null")]
+    $Ec2ConfigSetDnsSuffixList = "null"
 )
 
-if ($Ec2ConfigSetDnsSuffixList -ne $null)
+if ($Ec2ConfigSetDnsSuffixList -ne "null")
 {
     $EC2SettingsFile = "${env:ProgramFiles}\Amazon\Ec2ConfigService\Settings\Config.xml"
     $xml = [xml](get-content $EC2SettingsFile)


### PR DESCRIPTION
PowerShell in Windows 2016 throws an exception when attempting
to use $null in the ValidateSet.