### PR TITLE
Retries tests for host connectivity

### DIFF
--- a/templates/ra_guac_autoscale_public_alb.template.json
+++ b/templates/ra_guac_autoscale_public_alb.template.json
@@ -433,38 +433,6 @@
                 "Roles" : [ { "Ref" : "Ec2IamRole" } ]
             }
         },
-        "SsmAssociationUpdateAgent" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-UpdateSSMAgent",
-                "ScheduleExpression" : "rate(30 minutes)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
-        "SsmAssociationInstallPatches" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-RunPatchBaseline",
-                "Parameters" :
-                {
-                    "Operation" : [ "Install" ]
-                },
-                "ScheduleExpression" : "cron(0 6 ? * WED *)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
         "Ec2SecurityGroup" :
         {
             "Type" : "AWS::EC2::SecurityGroup",

--- a/templates/ra_rdcb_fileserver_ha.template.json
+++ b/templates/ra_rdcb_fileserver_ha.template.json
@@ -848,38 +848,6 @@
                 } ]
             }
         },
-        "SsmAssociationUpdateAgent" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-UpdateSSMAgent",
-                "ScheduleExpression" : "rate(30 minutes)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
-        "SsmAssociationInstallPatches" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-RunPatchBaseline",
-                "Parameters" :
-                {
-                    "Operation" : [ "Install" ]
-                },
-                "ScheduleExpression" : "cron(0 6 ? * WED *)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
         "RdsSubnetGroup" :
         {
             "Type" : "AWS::RDS::DBSubnetGroup",

--- a/templates/ra_rdcb_fileserver_standalone.template.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.json
@@ -631,38 +631,6 @@
                 } ]
             }
         },
-        "SsmAssociationUpdateAgent" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-UpdateSSMAgent",
-                "ScheduleExpression" : "rate(30 minutes)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
-        "SsmAssociationInstallPatches" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-RunPatchBaseline",
-                "Parameters" :
-                {
-                    "Operation" : [ "Install" ]
-                },
-                "ScheduleExpression" : "cron(0 6 ? * WED *)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
         "RdCbFileServerInstance" :
         {
             "Type" : "AWS::EC2::Instance",

--- a/templates/ra_rdgw_autoscale_public_elb.template.json
+++ b/templates/ra_rdgw_autoscale_public_elb.template.json
@@ -619,38 +619,6 @@
                 } ]
             }
         },
-        "SsmAssociationUpdateAgent" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-UpdateSSMAgent",
-                "ScheduleExpression" : "rate(30 minutes)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
-        "SsmAssociationInstallPatches" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-RunPatchBaseline",
-                "Parameters" :
-                {
-                    "Operation" : [ "Install" ]
-                },
-                "ScheduleExpression" : "cron(0 6 ? * WED *)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
         "ScaleUpScheduledAction" :
         {
             "Type" : "AWS::AutoScaling::ScheduledAction",

--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -672,38 +672,6 @@
                 } ]
             }
         },
-        "SsmAssociationUpdateAgent" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-UpdateSSMAgent",
-                "ScheduleExpression" : "rate(30 minutes)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
-        "SsmAssociationInstallPatches" :
-        {
-            "Type" : "AWS::SSM::Association",
-            "Properties" :
-            {
-                "Name" : "AWS-RunPatchBaseline",
-                "Parameters" :
-                {
-                    "Operation" : [ "Install" ]
-                },
-                "ScheduleExpression" : "cron(0 6 ? * WED *)",
-                "Targets" :
-                [ {
-                    "Key" : "tag:aws:cloudformation:stack-id",
-                    "Values" : [ { "Ref" : "AWS::StackId" } ]
-                } ]
-            }
-        },
         "ScaleUpScheduledAction" :
         {
             "Type" : "AWS::AutoScaling::ScheduledAction",


### PR DESCRIPTION
Addresses a race condition when multiple hosts are spinning up, and the execution of configure-rdsh.ps1 gets slightly delayed on (at least) one host for any reason. The race condition occurs if Host A completes and reboots, and at that moment Host B attempts to test connectivity to Host A, which of course fails. Previously, Host B would immediately remove Host A from the connection broker and/or remove the access rule for Host A from the profile share. Now, Host B will wait (currently 300 seconds) and then retry the test.

Also removing the SSM associations for the patch baseline, as the initial execution cannot be controlled and would sometimes interfere with the system install.