### PR TITLE
Converts to replacing updates

### DIFF
--- a/templates/ra_guac_autoscale_public_alb.template.json
+++ b/templates/ra_guac_autoscale_public_alb.template.json
@@ -653,17 +653,7 @@
             "Type" : "AWS::AutoScaling::AutoScalingGroup",
             "UpdatePolicy" :
             {
-                "AutoScalingRollingUpdate" :
-                {
-                    "MinInstancesInService" : "1",
-                    "MaxBatchSize" : "2",
-                    "WaitOnResourceSignals" : "true",
-                    "PauseTime" : "PT20M"
-                },
-                "AutoScalingScheduledAction" :
-                {
-                    "IgnoreUnmodifiedGroupSizeProperties" : "true"
-                }
+                "AutoScalingReplacingUpdate" : { "WillReplace" : "true" }
             },
             "CreationPolicy" :
             {

--- a/templates/ra_rdgw_autoscale_public_elb.template.json
+++ b/templates/ra_rdgw_autoscale_public_elb.template.json
@@ -653,18 +653,7 @@
             },
             "UpdatePolicy" :
             {
-                "AutoScalingRollingUpdate" :
-                {
-                    "MinInstancesInService" : "1",
-                    "MaxBatchSize" : "2",
-                    "WaitOnResourceSignals" : "true",
-                    "PauseTime" : "PT40M",
-                    "SuspendProcesses" : [ "ScheduledActions" ]
-                },
-                "AutoScalingScheduledAction" :
-                {
-                    "IgnoreUnmodifiedGroupSizeProperties" : "true"
-                }
+                "AutoScalingReplacingUpdate" : { "WillReplace" : "true" }
             },
             "Properties" :
             {

--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -686,18 +686,7 @@
             },
             "UpdatePolicy" :
             {
-                "AutoScalingRollingUpdate" :
-                {
-                    "MinInstancesInService" : { "Ref" : "MinCapacity" },
-                    "MaxBatchSize" : { "Ref" : "MaxCapacity" },
-                    "WaitOnResourceSignals" : "true",
-                    "PauseTime" : "PT60M",
-                    "SuspendProcesses" : [ "ScheduledActions" ]
-                },
-                "AutoScalingScheduledAction" :
-                {
-                    "IgnoreUnmodifiedGroupSizeProperties" : "true"
-                }
+                "AutoScalingReplacingUpdate" : { "WillReplace" : "true" }
             },
             "Properties" :
             {


### PR DESCRIPTION
Eliminates a lot of headaches around stack updates, and rollbacks in particular. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-replacingupdate