### PR TITLE
Corrects failing guac build

### DIFF
--- a/snippets/set_autoscaling_active_elx.snippet.yaml
+++ b/snippets/set_autoscaling_active_elx.snippet.yaml
@@ -1,7 +1,7 @@
 commands:
-  10-set-standby:
+  10-set-active:
     command:
-      - |
-        $instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
-        $asg_name=$(aws autoscaling describe-auto-scaling-instances --instance-ids $instance_id --query AutoScalingInstances[].AutoScalingGroupName --out text)
-        aws autoscaling exit-standby --instance-ids $instance_id --auto-scaling-group-name $asg_name
+      'Fn::Sub': |
+        instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+        asg_name=$(aws autoscaling describe-auto-scaling-instances --instance-ids $instance_id --query AutoScalingInstances[].AutoScalingGroupName --out text --region ${AWS::Region})
+        aws autoscaling exit-standby --instance-ids $instance_id --auto-scaling-group-name $asg_name --region ${AWS::Region}

--- a/snippets/set_autoscaling_standby_elx.snippet.yaml
+++ b/snippets/set_autoscaling_standby_elx.snippet.yaml
@@ -1,7 +1,11 @@
 commands:
   10-set-standby:
     command:
-      - |
-        $instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
-        $asg_name=$(aws autoscaling describe-auto-scaling-instances --instance-ids $instance_id --query AutoScalingInstances[].AutoScalingGroupName --out text)
-        aws autoscaling enter-standby --instance-ids $instance_id --auto-scaling-group-name $asg_name --should-decrement-desired-capacity
+      'Fn::Sub': |
+        instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+        asg_name=$(aws autoscaling describe-auto-scaling-instances --instance-ids $instance_id --query AutoScalingInstances[].AutoScalingGroupName --out text --region ${AWS::Region})
+        aws autoscaling enter-standby --instance-ids $instance_id --auto-scaling-group-name $asg_name --should-decrement-desired-capacity --region ${AWS::Region}
+        until [ "$(aws autoscaling describe-auto-scaling-instances --instance-ids $instance_id --query AutoScalingInstances[].LifecycleState --out text --region ${AWS::Region})" = "Standby" ]
+        do
+          sleep 5
+        done

--- a/templates/ra_guac_autoscale_public_alb.template.json
+++ b/templates/ra_guac_autoscale_public_alb.template.json
@@ -63,7 +63,7 @@
             "Description" : "The minimum number of instances for the autoscale group",
             "Type" : "String",
             "MinLength" : "1",
-            "Default" : "1"
+            "Default" : "0"
         },
         "MaxCapacity" :
         {
@@ -519,18 +519,6 @@
                 "AutoScalingGroupName" : { "Ref" : "AutoScalingGroup" },
                 "Cooldown" : "60",
                 "ScalingAdjustment" : "1"
-            }
-        },
-        "ScaleDownPolicy" :
-        {
-            "Type" : "AWS::AutoScaling::ScalingPolicy",
-            "Condition" : "UseScalingPolicy",
-            "Properties" :
-            {
-                "AdjustmentType" : "ChangeInCapacity",
-                "AutoScalingGroupName" : { "Ref" : "AutoScalingGroup" },
-                "Cooldown" : "60",
-                "ScalingAdjustment" : "-1"
             }
         },
         "CPUAlarmLow" :
@@ -993,7 +981,7 @@
                     " ( echo 'ERROR: cfn-init failed! Aborting!';",
                     " /opt/aws/bin/cfn-signal -e 1",
                     "  --stack ", { "Ref" : "AWS::StackName" },
-                    "  --resource SystemPrepAutoScalingGroup",
+                    "  --resource AutoScalingGroup",
                     "  --region ", { "Ref" : "AWS::Region"}, ";",
                     " exit 1",
                     " )\n\n"


### PR DESCRIPTION
* Entering standby takes a while. The aws command returns immediately, though. The guac install completes before the instance is actually in standby, so the command to exit standby was failing. Now we hold until the instance actually is in standby.
* Min instances needs to be zero, so on a new launch the instances can all place themselves in standby and decrement the desired capacity
* The scale down policy will actually reduce the capacity to zero though, so just removing this policy for the time being.