### PR TITLE
Handful more updates around additional edge cases

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -184,6 +184,10 @@ else
     Write-Verbose "Added system to RD Session Collection; SessionHost=${SystemName}, CollectionName=${CollectionName}"
 }
 
+# Disable new sessions until reboot
+Set-RDSessionHost -SessionHost $SystemName -NewConnectionAllowed "NotUntilReboot" -ConnectionBroker $ConnectionBroker
+Write-Verbose "Disabled new sessions until the host reboots"
+
 # Mark stale access rules on UPD share
 $StaleRules = @()
 $StaleUpdAcl = Get-Acl $UpdPath -ErrorAction Stop

--- a/snippets/set_autoscaling_standby_win.snippet.yaml
+++ b/snippets/set_autoscaling_standby_win.snippet.yaml
@@ -7,6 +7,7 @@ commands:
           $InstanceId = (New-Object Net.WebClient).Downloadstring('http://169.254.169.254/latest/meta-data/instance-id');
           $AsgName = $(Get-ASAutoScalingInstance -InstanceId $InstanceId -Region ${AWS::Region}).AutoScalingGroupName;
           Enter-ASStandby -InstanceId $InstanceId -AutoScalingGroupName $AsgName -shouldDecrementDesiredCapacity $True;
+          While ((Get-ASAutoScalingInstance -InstanceId $InstanceId -Region ${AWS::Region}).LifeCycleState -ne \"Standby\") { sleep 5 }
           } -Verbose -ErrorAction Stop
         -
           command:

--- a/templates/ra_rdcb_fileserver_standalone.template.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.json
@@ -841,7 +841,15 @@
             },
             "Properties" :
             {
-                "ImageId" : { "Ref" : "AmiId" },
+                "ImageId" :
+                {
+                    "Fn::If" :
+                    [
+                        "UseAmiLookup",
+                        {"Fn::GetAtt" : [ "AmiIdLookup", "Id" ]},
+                        {"Ref" : "AmiId"}
+                    ]
+                },
                 "InstanceType" : { "Ref" : "InstanceType" },
                 "DisableApiTermination" : "true",
                 "Monitoring" : "true",


### PR DESCRIPTION
- Pauses until instance fully enters standby before continuing
- Includes actual reference to the ami lookup value
- Reduces connectivity tests by keeping state of previously tested hosts
