### PR TITLE
Matches health grace period and cooldown to timeout policy

### DIFF
--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -696,7 +696,8 @@
                 "MinSize" : { "Ref" : "MinCapacity" },
                 "MaxSize" : { "Ref" : "MaxCapacity" },
                 "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
-                "HealthCheckGracePeriod" : "3600",
+                "Cooldown" : "4500",
+                "HealthCheckGracePeriod" : "4500",
                 "HealthCheckType" : "ELB",
                 "MetricsCollection" : [ { "Granularity" : "1Minute" } ],
                 "Tags" :


### PR DESCRIPTION
When the desired capacity is greater than the number of AZs associated
to the auto-scaling group, and when manually managing the active/standby
status of each instance, a potential race condition occurs. Here are the
conditions:

- One or more AZs have multiple instances
- All instances place themselves into standby
- Each instance progresses at its own pace
- Multiple instances in a single AZ exit standby
- At least one AZ contains 0 active instances

In this scenario, an AZ imbalance occurs and the auto-scaling group will
then terminate and launch instances to restore the AZ balance. Of course,
the only reason for the imbalance is because an instance has yet to exit
standby. When that instance becomes active again, the imbalance would
have been restored anyway, making the terminate/launch activity pointless
and actually *increasing* the total time for the pool to stabilize.

The patch is an attempt to address this race condition by setting the
cooldown period to match the timeout policy. The expectation is that the
cooldown period will prevent any new scaling actions, such as the
terminate/launch events, until the timeout policy expires. If the timeout
expires, then the instance likely failed somehow, and a new scaling
action would be desirable.