### PR TITLE
Disables the autoscaling azrebalance process explicitly

### DIFF
--- a/snippets/autoscaling_suspend_azrebalance_elx.snippet.yaml
+++ b/snippets/autoscaling_suspend_azrebalance_elx.snippet.yaml
@@ -1,0 +1,7 @@
+commands:
+  10-suspend-azrebalance:
+    command:
+      'Fn::Sub': |
+        instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+        asg_name=$(aws autoscaling describe-auto-scaling-instances --instance-ids $instance_id --query AutoScalingInstances[].AutoScalingGroupName --out text --region ${AWS::Region})
+        aws autoscaling suspend-processes --auto-scaling-group-name --auto-scaling-group-name $asg_name --scaling-processes AZRebalance --region ${AWS::Region}

--- a/snippets/autoscaling_suspend_azrebalance_win.snippet.yaml
+++ b/snippets/autoscaling_suspend_azrebalance_win.snippet.yaml
@@ -1,0 +1,17 @@
+commands:
+  10-suspend-azrebalance:
+    command:
+      'Fn::Sub':
+        - >
+          ${command} -Command Invoke-Command -ScriptBlock {
+          $InstanceId = (New-Object Net.WebClient).Downloadstring('http://169.254.169.254/latest/meta-data/instance-id');
+          $AsgName = $(Get-ASAutoScalingInstance -InstanceId $InstanceId -Region ${AWS::Region}).AutoScalingGroupName;
+          Suspend-ASProcess -AutoScalingGroupName $AsgName -ScalingProcess AZRebalance -Region ${AWS::Region}
+          } -Verbose -ErrorAction Stop
+        -
+          command:
+            'Fn::FindInMap':
+              - ShellCommandMap
+              - powershell
+              - command
+    waitAfterCompletion: '0'

--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -493,7 +493,8 @@
                             "Action" :
                             [
                                 "autoscaling:EnterStandby",
-                                "autoscaling:ExitStandby"
+                                "autoscaling:ExitStandby",
+                                "autoscaling:SuspendProcesses"
                             ],
                             "Resource" : "*",
                             "Condition" :
@@ -730,6 +731,7 @@
                         [
                             "join-domain",
                             "setup",
+                            "suspend-azrebalance",
                             "set-standby",
                             "installRDS",
                             "set-active",
@@ -737,6 +739,7 @@
                         ],
                         "update" :
                         [
+                            "suspend-azrebalance",
                             "set-standby",
                             "setup",
                             "set-active",
@@ -848,6 +851,17 @@
                             "Parameters" :
                             {
                                 "Location" : "s3://app-chemistry/snippets/set_autoscaling_active_win.snippet.yaml"
+                            }
+                        }
+                    },
+                    "suspend-azrebalance" :
+                    {
+                        "Fn::Transform" :
+                        {
+                            "Name" : "AWS::Include",
+                            "Parameters" :
+                            {
+                                "Location" : "s3://app-chemistry/snippets/autoscaling_suspend_azrebalance_win.snippet.yaml"
                             }
                         }
                     },


### PR DESCRIPTION
When the desired capacity is greater than the number of AZs associated
to the auto-scaling group, and when manually managing the active/standby
status of each instance, a potential race condition occurs. Here are the
conditions:

- One or more AZs have multiple instances
- All instances place themselves into standby
- Each instance progresses at its own pace
- Multiple instances in a single AZ exit standby
- At least one AZ contains 0 active instances

In this scenario, an AZ imbalance occurs and the auto-scaling group will
then terminate and launch instances to restore the AZ balance. Of course,
the only reason for the imbalance is because an instance has yet to exit
standby. When that instance becomes active again, the imbalance would
have been restored anyway, making the terminate/launch activity pointless
and actually *increasing* the total time for the pool to stabilize.

The race condition may also occur when the instances are entering standby,
if the AZRebalance process executes whenever zero instances are active
in one AZ and two or more instances are active in another AZ.

The patch is an attempt to address this race condition by disabling the
AZRebalance process entirely.