### PR TITLE
Looks for the metric in the correct namespace

### DIFF
--- a/templates/ra_rdcb_fileserver_standalone.template.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.json
@@ -1007,7 +1007,7 @@
                 } ],
                 "EvaluationPeriods" : "5",
                 "MetricName" : "LogicalDiskPercentFreeSpace_C",
-                "Namespace" : "Windows-Default",
+                "Namespace" : "AWS/EC2",
                 "Period" : "60",
                 "Statistic" : "Average",
                 "Threshold" : "40"
@@ -1028,7 +1028,7 @@
                 } ],
                 "EvaluationPeriods" : "5",
                 "MetricName" : "LogicalDiskPercentFreeSpace_C",
-                "Namespace" : "Windows-Default",
+                "Namespace" : "AWS/EC2",
                 "Period" : "60",
                 "Statistic" : "Average",
                 "Threshold" : "20"
@@ -1049,7 +1049,7 @@
                 } ],
                 "EvaluationPeriods" : "5",
                 "MetricName" : "LogicalDiskPercentFreeSpace_D",
-                "Namespace" : "Windows-Default",
+                "Namespace" : "AWS/EC2",
                 "Period" : "60",
                 "Statistic" : "Average",
                 "Threshold" : "40"
@@ -1070,7 +1070,7 @@
                 } ],
                 "EvaluationPeriods" : "5",
                 "MetricName" : "LogicalDiskPercentFreeSpace_D",
-                "Namespace" : "Windows-Default",
+                "Namespace" : "AWS/EC2",
                 "Period" : "60",
                 "Statistic" : "Average",
                 "Threshold" : "20"


### PR DESCRIPTION
Alarms were being marked as having No Data or INSUFFICIENT_DATA.
This was because the alarms were looking for the metric in the
wrong namespace.