### PR TITLE
Improves health check with an http endpoint

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -216,7 +216,7 @@ try
             Write-Verbose ("Testing connectivity to host: {0}" -f $RDServer.Server)
             try
             {
-                $TestRdp = Retry-TestCommand -Test Test-NetConnection -Args @{ComputerName=$RDServer.Server; CommonTCPPort="RDP"} -TestProperty "TcpTestSucceeded" -Tries 4 -SecondsDelay 45
+                $TestRdp = Retry-TestCommand -Test Test-NetConnection -Args @{ComputerName=$RDServer.Server; CommonTCPPort="RDP"} -TestProperty "TcpTestSucceeded" -Tries 7 -SecondsDelay 17
                 $ValidRDServers += $RDServer.Server
                 Write-Verbose "Successfully connected to host, $($RDServer.Server), keeping this RD Server"
             }
@@ -317,7 +317,7 @@ try
                 # Host is in ACL, but was not an RD Server; test connectivity and remove the rule if the host is not responding
                 try
                 {
-                    $TestRdp = Retry-TestCommand -Test Test-NetConnection -Args @{ComputerName=$Server; CommonTCPPort="RDP"} -TestProperty "TcpTestSucceeded" -Tries 4 -SecondsDelay 45
+                    $TestRdp = Retry-TestCommand -Test Test-NetConnection -Args @{ComputerName=$Server; CommonTCPPort="RDP"} -TestProperty "TcpTestSucceeded" -Tries 7 -SecondsDelay 17
                     Write-Verbose "Successfully connected to host, keeping this access rule"
                     Write-Verbose "    Host: $Server"
                     Write-Verbose ("    Rule Identity: {0}" -f $Rule.IdentityReference.Value)

--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -28,6 +28,12 @@ Param(
   [Switch] $HealthCheckEndPoint,
 
   [Parameter(Mandatory=$false,ValueFromPipeLine=$false,ValueFromPipeLineByPropertyName=$false)]
+  [String] $HealthCheckDir = "${Env:SystemDrive}\inetpub\wwwroot",
+
+  [Parameter(Mandatory=$false,ValueFromPipeLine=$false,ValueFromPipeLineByPropertyName=$false)]
+  [String] $HealthCheckSiteName = "Default Web Site",
+
+  [Parameter(Mandatory=$false,ValueFromPipeLine=$false,ValueFromPipeLineByPropertyName=$false)]
   [String] $HealthCheckPort = "8091"
 )
 
@@ -492,13 +498,42 @@ if ($HealthCheckEndPoint)
     Write-Verbose "Installed IIS to service health check requests"
 
     # Create the health check ping file
-    $HealthCheckPing = "${Env:SystemDrive}\inetpub\wwwroot\ping.html"
+    $HealthCheckPing = "${HealthCheckDir}\ping.html"
     $null = New-Item -Path $HealthCheckPing -ItemType File -Value "OK" -Force
     Write-Verbose "Created the health check ping file: ${HealthCheckPing}"
 
-    # Set the listening port
-    Set-WebBinding -Name "Default Web Site" -BindingInformation "*:80:" -PropertyName Port -Value $HealthCheckPort
-    Write-Verbose "Configured the health check endpoint to listen on ${HealthCheckPort}"
+    # Restrict the acl on the health check directory
+    $Acl = Get-Acl $HealthCheckDir
+    $Acl.SetAccessRuleProtection($True, $False)
+    $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule('IIS_IUSRS', 'ReadAndExecute', 'ContainerInherit, ObjectInherit', 'None', 'Allow')
+    $Acl.AddAccessRule($Rule)
+    $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule('IUSR', 'ReadAndExecute', 'ContainerInherit, ObjectInherit', 'None', 'Allow')
+    $Acl.AddAccessRule($Rule)
+    $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule('SYSTEM', 'FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow')
+    $Acl.AddAccessRule($Rule)
+    $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule('NT SERVICE\TrustedInstaller', 'FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow')
+    $Acl.AddAccessRule($Rule)
+    $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule('Administrators', 'FullControl', 'ContainerInherit, ObjectInherit', 'None', 'Allow')
+    $Acl.AddAccessRule($Rule)
+    $Rule = New-Object System.Security.AccessControl.FileSystemAccessRule('CREATOR OWNER', 'FullControl', 'ContainerInherit, ObjectInherit', 'InheritOnly', 'Allow')
+    $Acl.AddAccessRule($Rule)
+    Set-Acl $HealthCheckDir $Acl -ErrorAction Stop
+    Write-Verbose "Restricted the acl on the health check directory: ${HealthCheckDir}"
+
+    if (-not (Get-Website -Name $HealthCheckSiteName))
+    {
+        New-WebSite -Name $HealthCheckSiteName -PhysicalPath $HealthCheckDir -Port $HealthCheckPort
+        Write-Verbose "Created new health check site:"
+        Write-Verbose "    Name: ${HealthCheckSiteName}"
+        Write-Verbose "    Path: ${HealthCheckDir}"
+        Write-Verbose "    Port: ${HealthCheckPort}"
+    }
+    else
+    {
+        Get-WebBinding -Name $HealthCheckSiteName | % {Remove-WebBinding}
+        New-WebBinding -Name $HealthCheckSiteName -Port $HealthCheckPort
+        Write-Verbose "Configured the health check site to listen on ${HealthCheckPort}"
+    }
 
     # Open the firewall for the health check endpoint
     $Rule = @{

--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -492,8 +492,6 @@
                             "Effect" : "Allow",
                             "Action" :
                             [
-                                "autoscaling:EnterStandby",
-                                "autoscaling:ExitStandby",
                                 "autoscaling:SuspendProcesses"
                             ],
                             "Resource" : "*",
@@ -629,7 +627,7 @@
                 "CidrIp" : "0.0.0.0/0"
             }
         },
-        "PublicToElbIngressTcp8091" :
+        "RdshToElbIngressTcp8091" :
         {
             "Type" : "AWS::EC2::SecurityGroupIngress",
             "Properties" :
@@ -638,7 +636,7 @@
                 "IpProtocol" : "tcp",
                 "FromPort" : "8091",
                 "ToPort" : "8091",
-                "CidrIp" : "0.0.0.0/0"
+                "SourceSecurityGroupId" : { "Ref" : "Ec2SecurityGroup" }
             }
         },
         "ElbToRdshEgressTcp3389" :
@@ -675,7 +673,7 @@
                 {
                     "HealthyThreshold" : "5",
                     "Interval" : "60",
-                    "Target" : "TCP:3389",
+                    "Target" : "HTTP:8091/ping.html",
                     "Timeout" : "5",
                     "UnhealthyThreshold" : "10"
                 },
@@ -774,17 +772,13 @@
                             "join-domain",
                             "setup",
                             "suspend-azrebalance",
-                            "set-standby",
                             "installRDS",
-                            "set-active",
                             "finalize"
                         ],
                         "update" :
                         [
                             "suspend-azrebalance",
-                            "set-standby",
                             "setup",
-                            "set-active",
                             "finalize"
                         ]
                     },
@@ -871,28 +865,6 @@
                                         "Location" : "s3://app-chemistry/snippets/restrict_cfn_permissions.snippet.yaml"
                                     }
                                 }
-                            }
-                        }
-                    },
-                    "set-standby" :
-                    {
-                        "Fn::Transform" :
-                        {
-                            "Name" : "AWS::Include",
-                            "Parameters" :
-                            {
-                                "Location" : "s3://app-chemistry/snippets/set_autoscaling_standby_win.snippet.yaml"
-                            }
-                        }
-                    },
-                    "set-active" :
-                    {
-                        "Fn::Transform" :
-                        {
-                            "Name" : "AWS::Include",
-                            "Parameters" :
-                            {
-                                "Location" : "s3://app-chemistry/snippets/set_autoscaling_active_win.snippet.yaml"
                             }
                         }
                     },

--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -586,6 +586,18 @@
                 "SourceSecurityGroupId" : { "Ref" : "ElbSecurityGroup" }
             }
         },
+        "ElbToRdshIngressTcp8091" :
+        {
+            "Type" : "AWS::EC2::SecurityGroupIngress",
+            "Properties" :
+            {
+                "GroupId" : { "Ref" : "Ec2SecurityGroup" },
+                "IpProtocol" : "tcp",
+                "FromPort" : "8091",
+                "ToPort" : "8091",
+                "SourceSecurityGroupId" : { "Ref" : "ElbSecurityGroup" }
+            }
+        },
         "ElbSecurityGroup" :
         {
             "Type" : "AWS::EC2::SecurityGroup",
@@ -617,6 +629,18 @@
                 "CidrIp" : "0.0.0.0/0"
             }
         },
+        "PublicToElbIngressTcp8091" :
+        {
+            "Type" : "AWS::EC2::SecurityGroupIngress",
+            "Properties" :
+            {
+                "GroupId" : { "Ref" : "ElbSecurityGroup" },
+                "IpProtocol" : "tcp",
+                "FromPort" : "8091",
+                "ToPort" : "8091",
+                "CidrIp" : "0.0.0.0/0"
+            }
+        },
         "ElbToRdshEgressTcp3389" :
         {
             "Type" : "AWS::EC2::SecurityGroupEgress",
@@ -626,6 +650,18 @@
                 "IpProtocol" : "tcp",
                 "FromPort" : "3389",
                 "ToPort" : "3389",
+                "DestinationSecurityGroupId" : { "Ref" : "Ec2SecurityGroup" }
+            }
+        },
+        "ElbToRdshEgressTcp8091" :
+        {
+            "Type" : "AWS::EC2::SecurityGroupEgress",
+            "Properties" :
+            {
+                "GroupId" : { "Ref" : "ElbSecurityGroup" },
+                "IpProtocol" : "tcp",
+                "FromPort" : "8091",
+                "ToPort" : "8091",
                 "DestinationSecurityGroupId" : { "Ref" : "Ec2SecurityGroup" }
             }
         },
@@ -659,6 +695,12 @@
                         "InstanceProtocol" : "TCP",
                         "LoadBalancerPort" : "3389",
                         "Protocol" : "TCP"
+                    },
+                    {
+                        "InstancePort" : "8091",
+                        "InstanceProtocol" : "HTTP",
+                        "LoadBalancerPort" : "8091",
+                        "Protocol" : "HTTP"
                     }
                 ],
                 "Policies" : [],
@@ -960,7 +1002,9 @@
                                     "c:\\cfn\\files\\rdp.pfx",
                                     "' -PrivateKeyPassword '\"",
                                     { "Ref" : "RdpPrivateKeyPassword" },
-                                    "\"' -Verbose -ErrorAction Stop"
+                                    "\"'",
+                                    " -HealthCheckEndPoint",
+                                    " -Verbose -ErrorAction Stop"
                                 ]]},
                                 "waitAfterCompletion" : "0"
                             },


### PR DESCRIPTION
The HTTP endpoint is created after all the rdsh configuration is complete. The ELB health check will fail until the endpoint is created. While within the ELB health check grace period, this is ok and expected. If the script fails, the endpoint will not be created, and the ELB will eventually mark the host unhealthy, and the autoscaling group will terminate/re-launch. If the script does complete, the endpoint will be created, the instance will reboot, and the ELB healthcheck will begin succeeding, leading to the ELB marking the instance as healthy.

This is an improvement over the current approach, which manually manages the ASG status, as when the script fails it requires manual intervention to cleanup and get a new instance to launch.