### PR TITLE
Tests connectivity only once when updating ACL

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -323,7 +323,7 @@ try
                 # Host is in ACL, but was not an RD Server; test connectivity and remove the rule if the host is not responding
                 try
                 {
-                    $TestRdp = Retry-TestCommand -Test Test-NetConnection -Args @{ComputerName=$Server; CommonTCPPort="RDP"} -TestProperty "TcpTestSucceeded" -Tries 7 -SecondsDelay 17
+                    $TestRdp = Retry-TestCommand -Test Test-NetConnection -Args @{ComputerName=$Server; CommonTCPPort="RDP"} -TestProperty "TcpTestSucceeded" -Tries 1
                     Write-Verbose "Successfully connected to host, keeping this access rule"
                     Write-Verbose "    Host: $Server"
                     Write-Verbose ("    Rule Identity: {0}" -f $Rule.IdentityReference.Value)


### PR DESCRIPTION
At this point, any present rdsh nodes have already been tested,
and since this block is now serialized using the lockfile, new
rdsh nodes cannot come online in the time between the prior test
and this one. There is now no longer any reason to retry this
test.

Keep running the test through the retry command function, since
that function nicely checks the test property and will raise an
exception. This pattern is nicer than recreating that logic just
for this one test.