### PR TITLE
Uses raw github url to download psget

### DIFF
--- a/scripts/configure-rdsh.ps1
+++ b/scripts/configure-rdsh.ps1
@@ -507,7 +507,7 @@ $null = Start-Process -FilePath ${CabalExe} -ArgumentList ${CabalInstallParams} 
 Write-Verbose "Installed shellcheck"
 
 # Install PsGet, a PowerShell Module
-(new-object Net.WebClient).DownloadString("http://psget.net/GetPsGet.ps1") | iex
+(new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/psget/psget/master/GetPsGet.ps1") | iex
 Write-Verbose "Installed psget"
 
 # Install nuget, a PowerShell Module provider


### PR DESCRIPTION
Avoids the exception:

```
Exception calling "DownloadString" with "1" argument(s): "The remote server returned an error: (500) Internal Server
Error."
At line:1 char:1
+ (new-object Net.WebClient).DownloadString("http://psget.net/GetPsGet. ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException
```