### PR TITLE
Uses maxcapacity for the scaleup scheduled action

### DIFF
--- a/templates/ra_guac_autoscale_public_alb.template.json
+++ b/templates/ra_guac_autoscale_public_alb.template.json
@@ -488,7 +488,7 @@
             "Properties" :
             {
                 "AutoScalingGroupName" : { "Ref" : "AutoScalingGroup" },
-                "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
+                "DesiredCapacity" : { "Ref" : "MaxCapacity" },
                 "Recurrence" : { "Ref" : "ScaleUpSchedule" }
             }
         },

--- a/templates/ra_rdgw_autoscale_public_elb.template.json
+++ b/templates/ra_rdgw_autoscale_public_elb.template.json
@@ -488,7 +488,7 @@
             "Properties" :
             {
                 "AutoScalingGroupName" : { "Ref" : "AutoScalingGroup" },
-                "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
+                "DesiredCapacity" : { "Ref" : "MaxCapacity" },
                 "Recurrence" : { "Ref" : "ScaleUpSchedule" }
             }
         },

--- a/templates/ra_rdsh_autoscale_internal_elb.template.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.json
@@ -539,7 +539,7 @@
             "Properties" :
             {
                 "AutoScalingGroupName" : { "Ref" : "AutoScalingGroup" },
-                "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
+                "DesiredCapacity" : { "Ref" : "MaxCapacity" },
                 "Recurrence" : { "Ref" : "ScaleUpSchedule" }
             }
         },


### PR DESCRIPTION
Uses case for this change is when updating the stack while the
scale down condition is in effect... Prior to this patch, an update
would set the scale up action and the current capacity to the desired
capacity. This means that if you only want 1 instance *now*, because
the scale down action is in effect, you would to set the desired
capacity to 1, but that would have the consequence of also setting
the scale up action to a single instance.

This patch modifies the behavior so the scale up action is set to
the max capacity. This allows the desired capacity to be set to the
quantity needed now, while assiging the scale up action a greater
quantity.