### PR TITLE
Add UpdateSchedule custom resource

### DIFF
--- a/templates/ra_guac_autoscale_public_alb.template.cfn.json
+++ b/templates/ra_guac_autoscale_public_alb.template.cfn.json
@@ -17,6 +17,18 @@
                 ""
             ]
         },
+        "UseAutoUpdateStack": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "UpdateSchedule"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseBrandText": {
             "Fn::Not": [
                 {
@@ -311,6 +323,13 @@
             "Description": "Text/Label to display for the Second custom URL/link displayed on the Guac Login page",
             "Type": "String"
         },
+        "UpdateSchedule": {
+            "AllowedPattern": "^$|^cron\\(.*\\)$|^rate\\(.*\\)$|^$",
+            "ConstraintDescription": "Must be in CloudWatch events schedule expression format (Cron or Rate).",
+            "Default": "",
+            "Description": "(Optional) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html",
+            "Type": "String"
+        },
         "VPC": {
             "Description": "VPC ID",
             "Type": "AWS::EC2::VPC::Id"
@@ -491,6 +510,38 @@
                     "WillReplace": "true"
                 }
             }
+        },
+        "AutoUpdateStack": {
+            "Condition": "UseAutoUpdateStack",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::Join": [
+                        ":",
+                        [
+                            "arn:aws:lambda",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            "function:cfn-update-scheduler-dev-cfn_auto_update_broker"
+                        ]
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "ToggleParameter": "ForceUpdateToggle",
+                "ToggleValues": [
+                    "A",
+                    "B"
+                ],
+                "UpdateSchedule": {
+                    "Ref": "UpdateSchedule"
+                }
+            },
+            "Type": "Custom::AutoUpdateStack"
         },
         "CPUAlarmHigh": {
             "Condition": "UseScalingPolicy",

--- a/templates/ra_rdgw_autoscale_public_alb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_alb.template.cfn.json
@@ -17,6 +17,18 @@
                 ""
             ]
         },
+        "UseAutoUpdateStack": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "UpdateSchedule"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseScheduledAction": {
             "Fn::And": [
                 {
@@ -290,6 +302,13 @@
             ],
             "Default": "ACM",
             "Description": "The service hosting the SSL certificate",
+            "Type": "String"
+        },
+        "UpdateSchedule": {
+            "AllowedPattern": "^$|^cron\\(.*\\)$|^rate\\(.*\\)$|^$",
+            "ConstraintDescription": "Must be in CloudWatch events schedule expression format (Cron or Rate).",
+            "Default": "",
+            "Description": "(Optional) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html",
             "Type": "String"
         },
         "VPC": {
@@ -590,6 +609,38 @@
                     "WillReplace": "true"
                 }
             }
+        },
+        "AutoUpdateStack": {
+            "Condition": "UseAutoUpdateStack",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::Join": [
+                        ":",
+                        [
+                            "arn:aws:lambda",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            "function:cfn-update-scheduler-dev-cfn_auto_update_broker"
+                        ]
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "ToggleParameter": "ForceUpdateToggle",
+                "ToggleValues": [
+                    "A",
+                    "B"
+                ],
+                "UpdateSchedule": {
+                    "Ref": "UpdateSchedule"
+                }
+            },
+            "Type": "Custom::AutoUpdateStack"
         },
         "Ec2IamInstanceProfile": {
             "Properties": {

--- a/templates/ra_rdsh_autoscale_internal_elb.template.cfn.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.cfn.json
@@ -9,6 +9,18 @@
                 ""
             ]
         },
+        "UseAutoUpdateStack": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "UpdateSchedule"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "UseScheduledAction": {
             "Fn::And": [
                 {
@@ -318,6 +330,13 @@
             "Description": "List of Subnet IDs where the RDSH instances and ELB we be launched",
             "Type": "List<AWS::EC2::Subnet::Id>"
         },
+        "UpdateSchedule": {
+            "AllowedPattern": "^$|^cron\\(.*\\)$|^rate\\(.*\\)$|^$",
+            "ConstraintDescription": "Must be in CloudWatch events schedule expression format (Cron or Rate).",
+            "Default": "",
+            "Description": "(Optional) Time interval between auto stack updates. Refer to the AWS documentation for valid input syntax: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html",
+            "Type": "String"
+        },
         "UserProfileDiskPath": {
             "AllowedPattern": "^[\\\\\\\\]{2}[a-zA-Z0-9_\\\\-]+\\..+",
             "Default": "\\\\home.example.com\\Profiles$",
@@ -418,6 +437,38 @@
                     "WillReplace": "true"
                 }
             }
+        },
+        "AutoUpdateStack": {
+            "Condition": "UseAutoUpdateStack",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::Join": [
+                        ":",
+                        [
+                            "arn:aws:lambda",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            "function:cfn-update-scheduler-dev-cfn_auto_update_broker"
+                        ]
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "ToggleParameter": "ForceUpdateToggle",
+                "ToggleValues": [
+                    "A",
+                    "B"
+                ],
+                "UpdateSchedule": {
+                    "Ref": "UpdateSchedule"
+                }
+            },
+            "Type": "Custom::AutoUpdateStack"
         },
         "ELB": {
             "Properties": {


### PR DESCRIPTION
Adds the conditional parameter `UpdateSchedule` that when assigned, creates a scheduled stack update CloudWatch event using the [`plus3it/cfn-update-scheduler`](https://github.com/plus3it/cfn-update-scheduler) project.