### PR TITLE
Reverts rdgw alb back to use the elb

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.0.8
 commit = True
 message = Bumps version to {new_version}
 tag = False
@@ -113,7 +113,7 @@ replace = "Version": "{new_version}"
 search = "Version": "{current_version}"
 replace = "Version": "{new_version}"
 
-[bumpversion:file:templates/ra_rdgw_autoscale_public_alb.template.cfn.json]
+[bumpversion:file:templates/ra_rdgw_autoscale_public_lb.template.cfn.json]
 search = "Version": "{current_version}"
 replace = "Version": "{new_version}"
 

--- a/templates/db_mssql_alwayson.template.cfn.json
+++ b/templates/db_mssql_alwayson.template.cfn.json
@@ -302,7 +302,7 @@
                 }
             }
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "MssqlNode1InstanceId": {

--- a/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
+++ b/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template deploys a MySQL RDS instance",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "JDBCConnectionString": {

--- a/templates/ds_ad_primary_dc.element.template.cfn.json
+++ b/templates/ds_ad_primary_dc.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "DomainAdmin": {

--- a/templates/ds_ad_private_hosted_zone.element.template.cfn.json
+++ b/templates/ds_ad_private_hosted_zone.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Route53 private hosted zone, to resolve the domain to the AD Domain Controllers via DHCP.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "HostedZoneId": {

--- a/templates/ds_ad_replica_dc.element.template.cfn.json
+++ b/templates/ds_ad_replica_dc.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "DomainControllerID": {

--- a/templates/ds_ad_security_groups.element.template.cfn.json
+++ b/templates/ds_ad_security_groups.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates 2 security groups for an Active Directory domain -- one for Domain Controllers and one for Domain Members.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "DomainControllerSGID": {

--- a/templates/ds_dhcp_options.element.template.cfn.json
+++ b/templates/ds_dhcp_options.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates an Active Directory domain with a single domain controller. The default Domain Administrator password will be the one retrieved from the instance.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Parameters": {
         "DomainControllerIPs": {

--- a/templates/ds_singleaz_ad.compound.template.cfn.json
+++ b/templates/ds_singleaz_ad.compound.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template creates an Active Directory infrastructure in a Single AZ.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "DomainAdmin": {

--- a/templates/es_service_domain.element.template.cfn.json
+++ b/templates/es_service_domain.element.template.cfn.json
@@ -39,7 +39,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "DedicatedMasterCount": {

--- a/templates/nw_create_peer_role.element.template.cfn.json
+++ b/templates/nw_create_peer_role.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template creates an assumable role for cross account VPC peering.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "RoleARN": {

--- a/templates/nw_dualaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_dualaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -104,7 +104,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_dualaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_dualaz_multitier_natgateway.compound.template.cfn.json
@@ -94,7 +94,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_nat_gateway.element.template.cfn.json
+++ b/templates/nw_nat_gateway.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a NAT Gateway with an Elastic IP, Private route table with route to the NAT Gateway.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "NATGatewayElasticIP": {

--- a/templates/nw_nat_with_eni.element.template.cfn.json
+++ b/templates/nw_nat_with_eni.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "NATElasticNetworkInterfaceId": {

--- a/templates/nw_peered_sg.element.template.cfn.json
+++ b/templates/nw_peered_sg.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Security Group to allow remote access from instances in the specified security group within the peered account.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "VpcPeerSecurityGroupId": {

--- a/templates/nw_private_subnet.element.template.cfn.json
+++ b/templates/nw_private_subnet.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Private Subnet and associates it with a given Route Table.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "AvailabilityZoneName": {

--- a/templates/nw_public_subnet.element.template.cfn.json
+++ b/templates/nw_public_subnet.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Public Subnet and associates it with a given Route Table.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "AvailabilityZoneName": {

--- a/templates/nw_r53_peered_domain.element.template.cfn.json
+++ b/templates/nw_r53_peered_domain.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Route53 Private Hosted Zone and the associated resource records for a peered domain.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "PrivateHostedZoneId": {

--- a/templates/nw_singleaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_singleaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -101,7 +101,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_singleaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_singleaz_multitier_natgateway.compound.template.cfn.json
@@ -92,7 +92,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_tripleaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_tripleaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -108,7 +108,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_tripleaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_tripleaz_multitier_natgateway.compound.template.cfn.json
@@ -96,7 +96,7 @@
                 }
             ]
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_vpc_peering_connection.element.template.cfn.json
+++ b/templates/nw_vpc_peering_connection.element.template.cfn.json
@@ -52,7 +52,7 @@
     },
     "Description": "This element creates a VPC peering connection and adds the necessary route to specified route tables.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "VpcPeeringConnection": {

--- a/templates/nw_vpc_with_igw.element.template.cfn.json
+++ b/templates/nw_vpc_with_igw.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a VPC network with an Internet Gateway.",
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/ra_guac_autoscale_public_alb.template.cfn.json
+++ b/templates/ra_guac_autoscale_public_alb.template.cfn.json
@@ -150,7 +150,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "AlbSecurityGroupId": {

--- a/templates/ra_rdcb_fileserver_ha.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_ha.template.cfn.json
@@ -179,7 +179,7 @@
                 }
             }
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "RdcbEc2InstanceId": {

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -122,7 +122,7 @@
                 }
             }
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "RdcbEc2InstanceId": {

--- a/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
@@ -58,7 +58,7 @@
             ]
         }
     },
-    "Description": "This template deploys Remote Desktop Gateway (RDGW) instances in an autoscale group behind an Application LB, and joins them to a domain.",
+    "Description": "This template deploys Remote Desktop Gateway (RDGW) instances in an autoscale group behind a Load Balancer, and joins them to a domain.",
     "Mappings": {
         "InstanceTypeMap": {
             "Fn::Transform": {
@@ -119,7 +119,7 @@
                 },
                 {
                     "Label": {
-                        "default": "Application LB Configuration"
+                        "default": "Load Balancer Configuration"
                     },
                     "Parameters": [
                         "SslCertificateName",
@@ -148,31 +148,31 @@
         "Version": "0.0.7"
     },
     "Outputs": {
-        "AlbSecurityGroupId": {
-            "Description": "Security Group ID for RDGW Elastic Load Balancer",
-            "Value": {
-                "Ref": "AlbSecurityGroup"
-            }
-        },
         "Ec2SecurityGroupId": {
             "Description": "Security Group ID for RDGW EC2 instances",
             "Value": {
                 "Ref": "Ec2SecurityGroup"
             }
         },
+        "LbSecurityGroupId": {
+            "Description": "Security Group ID for RDGW Load Balancer",
+            "Value": {
+                "Ref": "LbSecurityGroup"
+            }
+        },
         "LoadBalancerDns": {
-            "Description": "DNS name for the ALB",
+            "Description": "DNS name for the LoadBalancer",
             "Value": {
                 "Fn::GetAtt": [
-                    "ALB",
+                    "LoadBalancer",
                     "DNSName"
                 ]
             }
         },
         "LoadBalancerName": {
-            "Description": "Name of the Elastic Load Balancer",
+            "Description": "Name of the Load Balancer",
             "Value": {
-                "Ref": "ALB"
+                "Ref": "LoadBalancer"
             }
         }
     },
@@ -293,7 +293,7 @@
             "Type": "String"
         },
         "SslCertificateName": {
-            "Description": "The name (for IAM) or identifier (for ACM) of the SSL certificate to associate with the ALB -- the cert must already exist in the service",
+            "Description": "The name (for IAM) or identifier (for ACM) of the SSL certificate to associate with the LB -- the cert must already exist in the service",
             "Type": "String"
         },
         "SslCertificateService": {
@@ -318,211 +318,6 @@
         }
     },
     "Resources": {
-        "ALB": {
-            "Properties": {
-                "LoadBalancerAttributes": [
-                    {
-                        "Key": "idle_timeout.timeout_seconds",
-                        "Value": "900"
-                    },
-                    {
-                        "Key": "routing.http2.enabled",
-                        "Value": "true"
-                    }
-                ],
-                "Scheme": "internet-facing",
-                "SecurityGroups": [
-                    {
-                        "Ref": "AlbSecurityGroup"
-                    }
-                ],
-                "Subnets": {
-                    "Ref": "PublicSubnetIDs"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }
-                ],
-                "Type": "application"
-            },
-            "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer"
-        },
-        "ALBTargetGroup": {
-            "Properties": {
-                "HealthCheckIntervalSeconds": "60",
-                "HealthCheckPath": "/ping.html",
-                "HealthCheckPort": "8091",
-                "HealthCheckProtocol": "HTTP",
-                "HealthCheckTimeoutSeconds": "5",
-                "HealthyThresholdCount": "5",
-                "Port": "443",
-                "Protocol": "HTTPS",
-                "TargetGroupAttributes": [
-                    {
-                        "Key": "deregistration_delay.timeout_seconds",
-                        "Value": "1800"
-                    }
-                ],
-                "UnhealthyThresholdCount": "10",
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::ElasticLoadBalancingV2::TargetGroup"
-        },
-        "AlbListener": {
-            "Properties": {
-                "Certificates": [
-                    {
-                        "CertificateArn": {
-                            "Fn::If": [
-                                "UseACM",
-                                {
-                                    "Fn::Join": [
-                                        ":",
-                                        [
-                                            "arn:aws:acm",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            {
-                                                "Ref": "AWS::AccountId"
-                                            },
-                                            {
-                                                "Fn::Join": [
-                                                    "",
-                                                    [
-                                                        "certificate/",
-                                                        {
-                                                            "Ref": "SslCertificateName"
-                                                        }
-                                                    ]
-                                                ]
-                                            }
-                                        ]
-                                    ]
-                                },
-                                {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "arn:aws:iam::",
-                                            {
-                                                "Ref": "AWS::AccountId"
-                                            },
-                                            ":server-certificate/",
-                                            {
-                                                "Ref": "SslCertificateName"
-                                            }
-                                        ]
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "DefaultActions": [
-                    {
-                        "TargetGroupArn": {
-                            "Ref": "ALBTargetGroup"
-                        },
-                        "Type": "forward"
-                    }
-                ],
-                "LoadBalancerArn": {
-                    "Ref": "ALB"
-                },
-                "Port": "443",
-                "Protocol": "HTTPS",
-                "SslPolicy": "ELBSecurityPolicy-TLS-1-2-2017-01"
-            },
-            "Type": "AWS::ElasticLoadBalancingV2::Listener"
-        },
-        "AlbSecurityGroup": {
-            "Properties": {
-                "GroupDescription": "Enable RDGW access from the Internet",
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": {
-                            "Fn::Join": [
-                                "",
-                                [
-                                    "ra-rdgw-alb-",
-                                    {
-                                        "Ref": "AWS::StackName"
-                                    }
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "VpcId": {
-                    "Ref": "VPC"
-                }
-            },
-            "Type": "AWS::EC2::SecurityGroup"
-        },
-        "AlbToEc2EgressTcp443": {
-            "Properties": {
-                "DestinationSecurityGroupId": {
-                    "Ref": "Ec2SecurityGroup"
-                },
-                "FromPort": "443",
-                "GroupId": {
-                    "Ref": "AlbSecurityGroup"
-                },
-                "IpProtocol": "tcp",
-                "ToPort": "443"
-            },
-            "Type": "AWS::EC2::SecurityGroupEgress"
-        },
-        "AlbToEc2EgressTcp8091": {
-            "Properties": {
-                "DestinationSecurityGroupId": {
-                    "Ref": "Ec2SecurityGroup"
-                },
-                "FromPort": "8091",
-                "GroupId": {
-                    "Ref": "AlbSecurityGroup"
-                },
-                "IpProtocol": "tcp",
-                "ToPort": "8091"
-            },
-            "Type": "AWS::EC2::SecurityGroupEgress"
-        },
-        "AlbToEc2IngressTcp443": {
-            "Properties": {
-                "FromPort": "443",
-                "GroupId": {
-                    "Ref": "Ec2SecurityGroup"
-                },
-                "IpProtocol": "tcp",
-                "SourceSecurityGroupId": {
-                    "Ref": "AlbSecurityGroup"
-                },
-                "ToPort": "443"
-            },
-            "Type": "AWS::EC2::SecurityGroupIngress"
-        },
-        "AlbToEc2IngressTcp8091": {
-            "Properties": {
-                "FromPort": "8091",
-                "GroupId": {
-                    "Ref": "Ec2SecurityGroup"
-                },
-                "IpProtocol": "tcp",
-                "SourceSecurityGroupId": {
-                    "Ref": "AlbSecurityGroup"
-                },
-                "ToPort": "8091"
-            },
-            "Type": "AWS::EC2::SecurityGroupIngress"
-        },
         "AmiIdLookup": {
             "Condition": "UseAmiLookup",
             "Properties": {
@@ -571,6 +366,11 @@
                 "LaunchConfigurationName": {
                     "Ref": "LaunchConfig"
                 },
+                "LoadBalancerNames": [
+                    {
+                        "Ref": "LoadBalancer"
+                    }
+                ],
                 "MaxSize": {
                     "Ref": "MaxCapacity"
                 },
@@ -589,11 +389,6 @@
                         "Value": {
                             "Ref": "AWS::StackName"
                         }
-                    }
-                ],
-                "TargetGroupARNs": [
-                    {
-                        "Ref": "ALBTargetGroup"
                     }
                 ],
                 "TerminationPolicies": [
@@ -786,7 +581,7 @@
         },
         "Ec2SecurityGroup": {
             "Properties": {
-                "GroupDescription": "Enable RDGW access from the ALB",
+                "GroupDescription": "Enable RDGW access from the Load Balancer",
                 "Tags": [
                     {
                         "Key": "Name",
@@ -1048,12 +843,198 @@
             },
             "Type": "AWS::AutoScaling::LaunchConfiguration"
         },
-        "PublicToAlbIngressTcp443": {
+        "LbSecurityGroup": {
+            "Properties": {
+                "GroupDescription": "Enable RDGW access from the Internet",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    "ra-rdgw-lb-",
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            },
+            "Type": "AWS::EC2::SecurityGroup"
+        },
+        "LbToEc2EgressTcp443": {
+            "Properties": {
+                "DestinationSecurityGroupId": {
+                    "Ref": "Ec2SecurityGroup"
+                },
+                "FromPort": "443",
+                "GroupId": {
+                    "Ref": "LbSecurityGroup"
+                },
+                "IpProtocol": "tcp",
+                "ToPort": "443"
+            },
+            "Type": "AWS::EC2::SecurityGroupEgress"
+        },
+        "LbToEc2EgressTcp8091": {
+            "Properties": {
+                "DestinationSecurityGroupId": {
+                    "Ref": "Ec2SecurityGroup"
+                },
+                "FromPort": "8091",
+                "GroupId": {
+                    "Ref": "LbSecurityGroup"
+                },
+                "IpProtocol": "tcp",
+                "ToPort": "8091"
+            },
+            "Type": "AWS::EC2::SecurityGroupEgress"
+        },
+        "LbToEc2IngressTcp443": {
+            "Properties": {
+                "FromPort": "443",
+                "GroupId": {
+                    "Ref": "Ec2SecurityGroup"
+                },
+                "IpProtocol": "tcp",
+                "SourceSecurityGroupId": {
+                    "Ref": "LbSecurityGroup"
+                },
+                "ToPort": "443"
+            },
+            "Type": "AWS::EC2::SecurityGroupIngress"
+        },
+        "LbToEc2IngressTcp8091": {
+            "Properties": {
+                "FromPort": "8091",
+                "GroupId": {
+                    "Ref": "Ec2SecurityGroup"
+                },
+                "IpProtocol": "tcp",
+                "SourceSecurityGroupId": {
+                    "Ref": "LbSecurityGroup"
+                },
+                "ToPort": "8091"
+            },
+            "Type": "AWS::EC2::SecurityGroupIngress"
+        },
+        "LoadBalancer": {
+            "Properties": {
+                "ConnectionDrainingPolicy": {
+                    "Enabled": "true",
+                    "Timeout": "1800"
+                },
+                "ConnectionSettings": {
+                    "IdleTimeout": "900"
+                },
+                "CrossZone": "false",
+                "HealthCheck": {
+                    "HealthyThreshold": "5",
+                    "Interval": "60",
+                    "Target": "HTTP:8091/ping.html",
+                    "Timeout": "5",
+                    "UnhealthyThreshold": "10"
+                },
+                "Listeners": [
+                    {
+                        "InstancePort": "443",
+                        "InstanceProtocol": "SSL",
+                        "LoadBalancerPort": "443",
+                        "Protocol": "SSL",
+                        "SSLCertificateId": {
+                            "Fn::If": [
+                                "UseACM",
+                                {
+                                    "Fn::Join": [
+                                        ":",
+                                        [
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "acm",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            {
+                                                "Ref": "AWS::AccountId"
+                                            },
+                                            {
+                                                "Fn::Join": [
+                                                    "",
+                                                    [
+                                                        "certificate/",
+                                                        {
+                                                            "Ref": "SslCertificateName"
+                                                        }
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "iam",
+                                            {
+                                                "Ref": "AWS::AccountId"
+                                            },
+                                            ":server-certificate/",
+                                            {
+                                                "Ref": "SslCertificateName"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "InstancePort": "8091",
+                        "InstanceProtocol": "HTTP",
+                        "LoadBalancerPort": "8091",
+                        "Protocol": "HTTP"
+                    }
+                ],
+                "Policies": [],
+                "Scheme": "internet-facing",
+                "SecurityGroups": [
+                    {
+                        "Ref": "LbSecurityGroup"
+                    }
+                ],
+                "Subnets": {
+                    "Ref": "PublicSubnetIDs"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    }
+                ]
+            },
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+        },
+        "PublicToLbIngressTcp443": {
             "Properties": {
                 "CidrIp": "0.0.0.0/0",
                 "FromPort": "443",
                 "GroupId": {
-                    "Ref": "AlbSecurityGroup"
+                    "Ref": "LbSecurityGroup"
                 },
                 "IpProtocol": "tcp",
                 "ToPort": "443"

--- a/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
@@ -145,7 +145,7 @@
                 }
             }
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "Ec2SecurityGroupId": {

--- a/templates/ra_rdsh_autoscale_internal_elb.template.cfn.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.cfn.json
@@ -136,7 +136,7 @@
                 }
             }
         },
-        "Version": "0.0.7"
+        "Version": "0.0.8"
     },
     "Outputs": {
         "Ec2SecurityGroupId": {


### PR DESCRIPTION
The ALB has no mechanism for disabling cross-zone load-balancing,
but the RDGW cannot scale-out past a single instance when cross-
zone load-balancing is enabled.