### PR TITLE
Extends first partition on each volume during launch/update events

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.9
+current_version = 0.1.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/templates/db_mssql_alwayson.template.cfn.json
+++ b/templates/db_mssql_alwayson.template.cfn.json
@@ -302,7 +302,7 @@
                 }
             }
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "MssqlNode1InstanceId": {

--- a/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
+++ b/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template deploys a MySQL RDS instance",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "JDBCConnectionString": {

--- a/templates/ds_ad_primary_dc.element.template.cfn.json
+++ b/templates/ds_ad_primary_dc.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "DomainAdmin": {

--- a/templates/ds_ad_private_hosted_zone.element.template.cfn.json
+++ b/templates/ds_ad_private_hosted_zone.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Route53 private hosted zone, to resolve the domain to the AD Domain Controllers via DHCP.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "HostedZoneId": {

--- a/templates/ds_ad_replica_dc.element.template.cfn.json
+++ b/templates/ds_ad_replica_dc.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "DomainControllerID": {

--- a/templates/ds_ad_security_groups.element.template.cfn.json
+++ b/templates/ds_ad_security_groups.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates 2 security groups for an Active Directory domain -- one for Domain Controllers and one for Domain Members.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "DomainControllerSGID": {

--- a/templates/ds_dhcp_options.element.template.cfn.json
+++ b/templates/ds_dhcp_options.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates an Active Directory domain with a single domain controller. The default Domain Administrator password will be the one retrieved from the instance.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Parameters": {
         "DomainControllerIPs": {

--- a/templates/ds_singleaz_ad.compound.template.cfn.json
+++ b/templates/ds_singleaz_ad.compound.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template creates an Active Directory infrastructure in a Single AZ.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "DomainAdmin": {

--- a/templates/es_service_domain.element.template.cfn.json
+++ b/templates/es_service_domain.element.template.cfn.json
@@ -39,7 +39,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "DedicatedMasterCount": {

--- a/templates/nw_create_peer_role.element.template.cfn.json
+++ b/templates/nw_create_peer_role.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template creates an assumable role for cross account VPC peering.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "RoleARN": {

--- a/templates/nw_dualaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_dualaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -104,7 +104,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_dualaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_dualaz_multitier_natgateway.compound.template.cfn.json
@@ -94,7 +94,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_nat_gateway.element.template.cfn.json
+++ b/templates/nw_nat_gateway.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a NAT Gateway with an Elastic IP, Private route table with route to the NAT Gateway.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "NATGatewayElasticIP": {

--- a/templates/nw_nat_with_eni.element.template.cfn.json
+++ b/templates/nw_nat_with_eni.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "NATElasticNetworkInterfaceId": {

--- a/templates/nw_peered_sg.element.template.cfn.json
+++ b/templates/nw_peered_sg.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Security Group to allow remote access from instances in the specified security group within the peered account.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "VpcPeerSecurityGroupId": {

--- a/templates/nw_private_subnet.element.template.cfn.json
+++ b/templates/nw_private_subnet.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Private Subnet and associates it with a given Route Table.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "AvailabilityZoneName": {

--- a/templates/nw_public_subnet.element.template.cfn.json
+++ b/templates/nw_public_subnet.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Public Subnet and associates it with a given Route Table.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "AvailabilityZoneName": {

--- a/templates/nw_r53_peered_domain.element.template.cfn.json
+++ b/templates/nw_r53_peered_domain.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Route53 Private Hosted Zone and the associated resource records for a peered domain.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "PrivateHostedZoneId": {

--- a/templates/nw_singleaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_singleaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -101,7 +101,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_singleaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_singleaz_multitier_natgateway.compound.template.cfn.json
@@ -92,7 +92,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_tripleaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_tripleaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -108,7 +108,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_tripleaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_tripleaz_multitier_natgateway.compound.template.cfn.json
@@ -96,7 +96,7 @@
                 }
             ]
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_vpc_peering_connection.element.template.cfn.json
+++ b/templates/nw_vpc_peering_connection.element.template.cfn.json
@@ -52,7 +52,7 @@
     },
     "Description": "This element creates a VPC peering connection and adds the necessary route to specified route tables.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "VpcPeeringConnection": {

--- a/templates/nw_vpc_with_igw.element.template.cfn.json
+++ b/templates/nw_vpc_with_igw.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a VPC network with an Internet Gateway.",
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/ra_guac_autoscale_public_alb.template.cfn.json
+++ b/templates/ra_guac_autoscale_public_alb.template.cfn.json
@@ -150,7 +150,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "AlbSecurityGroupId": {

--- a/templates/ra_rdcb_fileserver_ha.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_ha.template.cfn.json
@@ -207,7 +207,7 @@
                 }
             }
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "RdcbEc2InstanceId": {

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -701,7 +701,12 @@
                                 "ignoreErrors": "true",
                                 "waitAfterCompletion": "0"
                             },
-                            "d-unzip-pstools": {
+                            "d-extend-disks": {
+                                "command": "powershell.exe c:\\cfn\\scripts\\extend-volumes.ps1 -verbose",
+                                "ignoreErrors": "true",
+                                "waitAfterCompletion": "0"
+                            },
+                            "e-unzip-pstools": {
                                 "command": "powershell.exe c:\\cfn\\scripts\\unzip-archive.ps1 c:\\cfn\\files\\pstools.zip c:\\cfn\\files\\pstools",
                                 "ignoreErrors": "true",
                                 "waitAfterCompletion": "0"
@@ -766,6 +771,29 @@
                             },
                             "c:\\cfn\\scripts\\configure-rdcb.ps1": {
                                 "source": "https://raw.githubusercontent.com/plus3it/cfn/master/scripts/configure-rdcb.ps1"
+                            },
+                            "c:\\cfn\\scripts\\extend-volumes.ps1": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[CmdLetBinding()]\n",
+                                            "Param()\n",
+                                            "foreach ($disk in (Get-Disk)) {\n",
+                                            "    $disk | Update-Disk\n",
+                                            "    $Size = (Get-Partition -DiskNumber $disk.Number -PartitionNumber 1).size\n",
+                                            "    $SizeMax = (Get-PartitionSupportedSize -DiskNumber $disk.Number).SizeMax\n",
+                                            "    Write-Verbose \"Disk: $($disk.Number); Current Size: $Size; Maximum Size: $SizeMax\"\n",
+                                            "    if ($SizeMax -gt $Size) {\n",
+                                            "        Resize-Partition -DiskNumber $disk.Number -PartitionNumber 1 -Size $SizeMax\n",
+                                            "        Write-Verbose \"Extended disk $($disk.Number) partition 1\"\n",
+                                            "    } else {\n",
+                                            "        Write-Verbose \"No change to disk $($disk.Number) partition 1\"\n",
+                                            "    }\n",
+                                            "}\n"
+                                        ]
+                                    ]
+                                }
                             },
                             "c:\\cfn\\scripts\\snap-by-group.ps1": {
                                 "source": "https://raw.githubusercontent.com/plus3it/WinEBSbackups/master/SnapByCgroup.ps1"

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -1293,6 +1293,11 @@
                             }
                         }
                     }
+                },
+                "CfnUpdateTriggers": {
+                    "EbsVolumeSize": {
+                        "Ref": "DataVolumeSize"
+                    }
                 }
             },
             "Properties": {

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -142,7 +142,7 @@
                 }
             }
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "RdcbEc2InstanceId": {

--- a/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
@@ -165,7 +165,7 @@
                 }
             }
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "Ec2SecurityGroupId": {

--- a/templates/ra_rdsh_autoscale_internal_elb.template.cfn.json
+++ b/templates/ra_rdsh_autoscale_internal_elb.template.cfn.json
@@ -156,7 +156,7 @@
                 }
             }
         },
-        "Version": "0.0.9"
+        "Version": "0.1.0"
     },
     "Outputs": {
         "Ec2SecurityGroupId": {


### PR DESCRIPTION
CloudFormation seems to work well with the Elastic Volume feature of EBS, so you can modify the volume size in a stack update and it does the right thing (it does not destroy and recreate the volume, it just increases the capacity).

However, the OS is unaware of the new capacity. This patch adds the EBS Volume Size to the metadata of the EC2 instance. The cfn-hup utility is monitoring the metadata for changes, and when changes are detected it executes cfn-init and applies the "update" configset. Also, a powershell script is added to the update configset that will test if there is available capacity in any of the attached disks, and extend partition 1 over the available space. Since we only have one partition per disk, this approach works fine for this use case.

Also, due to the way the resources are created and the linked dependencies, the metadata update on the EC2 instance does not occur until the EBS volume has been extended successfully. This addresses the potential race condition where the OS might attempt to extend the volume before the additional capacity is available.

In the cfn-init-cmd.log file, the output looks like this:

```
2018-11-03 00:44:40,226 P8972 [INFO] Command d-extend-disks
2018-11-03 00:44:46,032 P8972 [INFO] -----------------------Command Output-----------------------
2018-11-03 00:44:46,032 P8972 [INFO] 	VERBOSE: Disk: 0; Current Size: 53684994048; Maximum Size: 53684994048
2018-11-03 00:44:46,032 P8972 [INFO] 	VERBOSE: No change to disk 0 partition 1
2018-11-03 00:44:46,032 P8972 [INFO] 	VERBOSE: Disk: 1; Current Size: 110593310720; Maximum Size: 111667052544
2018-11-03 00:44:46,032 P8972 [INFO] 	VERBOSE: Extended disk 1 partition 1
2018-11-03 00:44:46,032 P8972 [INFO] ------------------------------------------------------------
2018-11-03 00:44:46,032 P8972 [INFO] Completed successfully.
```