### PR TITLE
Updates cloudwatch agent install to be fully non-interactive

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# see http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+[.bumpversion.cfg]
+indent_style = tab
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2

--- a/psmodules/P3Utils/P3Utils.psd1
+++ b/psmodules/P3Utils/P3Utils.psd1
@@ -1,0 +1,118 @@
+#
+# Module manifest for module 'P3RemoteAccess'
+#
+
+@{
+
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'P3Utils.psm1'
+
+    # Version number of this module.
+    ModuleVersion = '1.0'
+
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
+
+    # ID used to uniquely identify this module
+    GUID = 'a4000f16-e896-4c48-bf7c-922db0de2063'
+
+    # Author of this module
+    Author = 'Plus3 IT Systems'
+
+    # Company or vendor of this module
+    CompanyName = 'Plus3 IT Systems'
+
+    # Copyright statement for this module
+    Copyright = '(c) 2019 Maintainers of plus3it/cfn. All rights reserved.'
+
+    # Description of the functionality provided by this module
+    # Description = ''
+
+    # Minimum version of the Windows PowerShell engine required by this module
+    # PowerShellVersion = ''
+
+    # Name of the Windows PowerShell host required by this module
+    # PowerShellHostName = ''
+
+    # Minimum version of the Windows PowerShell host required by this module
+    # PowerShellHostVersion = ''
+
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
+
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # CLRVersion = ''
+
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
+
+    # Modules that must be imported into the global environment prior to importing this module
+    # RequiredModules = @()
+
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
+
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
+
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = @()
+
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = @()
+
+    # Variables to export from this module
+    VariablesToExport = '*'
+
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
+
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
+
+    # List of all modules packaged with this module
+    # ModuleList = @()
+
+    # List of all files packaged with this module
+    # FileList = @()
+
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+
+        PSData = @{
+
+            # Tags applied to this module. These help with module discovery in online galleries.
+            # Tags = @()
+
+            # A URL to the license for this module.
+            # LicenseUri = ''
+
+            # A URL to the main website for this project.
+            # ProjectUri = ''
+
+            # A URL to an icon representing this module.
+            # IconUri = ''
+
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
+
+        } # End of PSData hashtable
+
+    } # End of PrivateData hashtable
+
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
+
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+
+}

--- a/psmodules/P3Utils/P3Utils.psm1
+++ b/psmodules/P3Utils/P3Utils.psm1
@@ -1,0 +1,80 @@
+function global:Invoke-RetryCommand {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Command,
+
+        [Parameter(Mandatory=$false)]
+        $ArgList = @{},
+
+        [Parameter(Mandatory=$false)]
+        [string]
+        $CheckExpression = '$? -and $Return.Result',
+
+        [Parameter(Mandatory=$false)]
+        [int]
+        $Tries = 5,
+
+        [Parameter(Mandatory=$false)]
+        [int]
+        $InitialDelay = 2,  # in seconds
+
+        [Parameter(Mandatory=$false)]
+        [int]
+        $MaxDelay = 32  # in seconds
+    )
+    Begin {
+        $TryCount = 0
+        $Delay = $InitialDelay
+        $Completed = $false
+        $MsgFailed = "Command FAILED: {0}" -f $Command
+        $MsgSucceeded = "Command SUCCEEDED: {0}" -f $Command
+        $ArgString = if ($ArgList -is [Hashtable]) { $ArgList | Select-Object -Property * | Out-String } else { $ArgList -join " "}
+        $Return = @{Result=$Null}
+
+        Write-Verbose ("Tries: {0}" -f $Tries)
+        Write-Verbose ("Command: {0}" -f $Command)
+        Write-Verbose ("ArgList: {0}" -f $ArgString)
+    }
+    Process {
+        while (-not $Completed)
+        {
+            try
+            {
+                $Return.Result = & $Command @ArgList
+                if (-not (Invoke-Expression $CheckExpression))
+                {
+                    throw $MsgFailed
+                }
+                else
+                {
+                    Write-Verbose $MsgSucceeded
+                    Write-Output $Return.Result
+                    $Completed = $true
+                }
+            }
+            catch
+            {
+                $TryCount++
+                if ($TryCount -ge $Tries)
+                {
+                    $Completed = $true
+                    Write-Output $Return.Result
+                    Write-Warning ($PSItem | Select-Object -Property * | Out-String)
+                    Write-Warning ("Command failed the maximum number of {0} time(s)." -f $Tries)
+                    $PSCmdlet.ThrowTerminatingError($PSItem)
+                }
+                else
+                {
+                    $Msg = $PSItem.ToString()
+                    if ($Msg -ne $MsgFailed) { Write-Warning $Msg }
+                    Write-Warning ("Command failed. Retrying in {0} second(s)." -f $Delay)
+                    Start-Sleep $Delay
+                    $Delay *= 2
+                    $Delay = [Math]::Min($MaxDelay, $Delay)
+                }
+            }
+        }
+    }
+    End {}
+}

--- a/templates/db_mssql_alwayson.template.cfn.json
+++ b/templates/db_mssql_alwayson.template.cfn.json
@@ -298,7 +298,7 @@
                 }
             }
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "MssqlNode1InstanceId": {

--- a/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
+++ b/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template deploys a MySQL RDS instance",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "JDBCConnectionString": {

--- a/templates/ds_ad_primary_dc.element.template.cfn.json
+++ b/templates/ds_ad_primary_dc.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "DomainAdmin": {

--- a/templates/ds_ad_private_hosted_zone.element.template.cfn.json
+++ b/templates/ds_ad_private_hosted_zone.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Route53 private hosted zone, to resolve the domain to the AD Domain Controllers via DHCP.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "HostedZoneId": {

--- a/templates/ds_ad_replica_dc.element.template.cfn.json
+++ b/templates/ds_ad_replica_dc.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "DomainControllerID": {

--- a/templates/ds_ad_security_groups.element.template.cfn.json
+++ b/templates/ds_ad_security_groups.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates 2 security groups for an Active Directory domain -- one for Domain Controllers and one for Domain Members.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "DomainControllerSGID": {

--- a/templates/ds_dhcp_options.element.template.cfn.json
+++ b/templates/ds_dhcp_options.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates an Active Directory domain with a single domain controller. The default Domain Administrator password will be the one retrieved from the instance.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Parameters": {
         "DomainControllerIPs": {

--- a/templates/ds_singleaz_ad.compound.template.cfn.json
+++ b/templates/ds_singleaz_ad.compound.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template creates an Active Directory infrastructure in a Single AZ.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "DomainAdmin": {

--- a/templates/es_service_domain.element.template.cfn.json
+++ b/templates/es_service_domain.element.template.cfn.json
@@ -39,7 +39,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "DedicatedMasterCount": {

--- a/templates/nw_create_peer_role.element.template.cfn.json
+++ b/templates/nw_create_peer_role.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This template creates an assumable role for cross account VPC peering.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "RoleARN": {

--- a/templates/nw_dualaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_dualaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -104,7 +104,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_dualaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_dualaz_multitier_natgateway.compound.template.cfn.json
@@ -94,7 +94,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_nat_gateway.element.template.cfn.json
+++ b/templates/nw_nat_gateway.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a NAT Gateway with an Elastic IP, Private route table with route to the NAT Gateway.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "NATGatewayElasticIP": {

--- a/templates/nw_nat_with_eni.element.template.cfn.json
+++ b/templates/nw_nat_with_eni.element.template.cfn.json
@@ -56,7 +56,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "NATElasticNetworkInterfaceId": {

--- a/templates/nw_peered_sg.element.template.cfn.json
+++ b/templates/nw_peered_sg.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Security Group to allow remote access from instances in the specified security group within the peered account.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "VpcPeerSecurityGroupId": {

--- a/templates/nw_private_subnet.element.template.cfn.json
+++ b/templates/nw_private_subnet.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Private Subnet and associates it with a given Route Table.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "AvailabilityZoneName": {

--- a/templates/nw_public_subnet.element.template.cfn.json
+++ b/templates/nw_public_subnet.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Public Subnet and associates it with a given Route Table.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "AvailabilityZoneName": {

--- a/templates/nw_r53_peered_domain.element.template.cfn.json
+++ b/templates/nw_r53_peered_domain.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a Route53 Private Hosted Zone and the associated resource records for a peered domain.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "PrivateHostedZoneId": {

--- a/templates/nw_singleaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_singleaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -101,7 +101,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_singleaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_singleaz_multitier_natgateway.compound.template.cfn.json
@@ -92,7 +92,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_tripleaz_multitier_nat_with_eni.compound.template.cfn.json
+++ b/templates/nw_tripleaz_multitier_nat_with_eni.compound.template.cfn.json
@@ -108,7 +108,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_tripleaz_multitier_natgateway.compound.template.cfn.json
+++ b/templates/nw_tripleaz_multitier_natgateway.compound.template.cfn.json
@@ -96,7 +96,7 @@
                 }
             ]
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/nw_vpc_peering_connection.element.template.cfn.json
+++ b/templates/nw_vpc_peering_connection.element.template.cfn.json
@@ -52,7 +52,7 @@
     },
     "Description": "This element creates a VPC peering connection and adds the necessary route to specified route tables.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "VpcPeeringConnection": {

--- a/templates/nw_vpc_with_igw.element.template.cfn.json
+++ b/templates/nw_vpc_with_igw.element.template.cfn.json
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "This element creates a VPC network with an Internet Gateway.",
     "Metadata": {
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "InternetGatewayId": {

--- a/templates/ra_guac_autoscale_public_alb.template.cfn.json
+++ b/templates/ra_guac_autoscale_public_alb.template.cfn.json
@@ -150,7 +150,7 @@
         }
     },
     "Metadata": {
-        "Version": "0.3.0",
+        "Version": "0.3.1",
         "cfn-lint": {
             "config": {
                 "ignore_checks": [

--- a/templates/ra_rdcb_fileserver_ha.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_ha.template.cfn.json
@@ -207,7 +207,7 @@
                 }
             }
         },
-        "Version": "0.3.0"
+        "Version": "0.3.1"
     },
     "Outputs": {
         "RdcbEc2InstanceId": {

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -141,7 +141,7 @@
                 }
             }
         },
-        "Version": "0.3.0",
+        "Version": "0.3.1",
         "cfn-lint": {
             "config": {
                 "ignore_checks": [

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -828,8 +828,9 @@
                     },
                     "configSets": {
                         "launch": [
-                            "install-cloudwatch-agent",
                             "join-domain",
+                            "ps-modules",
+                            "install-cloudwatch-agent",
                             "cfnsetup",
                             "install-roles",
                             "reboot",
@@ -841,6 +842,7 @@
                             "finalize"
                         ],
                         "update": [
+                            "ps-modules",
                             "cfnsetup",
                             "finalize"
                         ]
@@ -1071,6 +1073,7 @@
                                             },
                                             " -Command \"Invoke-Command -ScriptBlock { ",
                                             "$ErrorActionPreference = 'Stop'; ",
+                                            "Import-Module P3Utils; ",
                                             "$CloudWatchAgentUri = [System.Uri]'",
                                             {
                                                 "Ref": "CloudWatchAgentUrl"
@@ -1089,7 +1092,7 @@
                                             },
                                             "; ",
                                             "$CloudWatchAgentConfig =  $CloudWatchAgentScriptDir + '\\aws-cloudwatch-agent-config.json'; ",
-                                            "Start-Process msiexec.exe -ArgumentList @('/i', $CloudWatchAgentInstaller, '/qn') -NoNewWindow -PassThru -Wait; ",
+                                            "Invoke-RetryCommand -Command Start-Process -ArgList @{ FilePath='msiexec.exe'; ArgumentList = @('/i', $CloudWatchAgentInstaller, '/qn'); NoNewWindow = $true; PassThru = $true; Wait = $true } -CheckExpression '$Return.Result.ExitCode -eq 0' -InitialDelay 17 -MaxDelay 59 -Verbose; ",
                                             "$CloudWatchAgentCtl = \\\"${Env:ProgramFiles}\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\\\"; ",
                                             "& $CloudWatchAgentCtl -Action cond-restart; ",
                                             "& $CloudWatchAgentCtl -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s; ",
@@ -1303,6 +1306,16 @@
                                     ]
                                 },
                                 "waitAfterCompletion": "forever"
+                            }
+                        }
+                    },
+                    "ps-modules": {
+                        "files": {
+                            "C:\\Program Files\\WindowsPowerShell\\Modules\\P3Utils\\P3Utils.psd1": {
+                                "source": "https://raw.githubusercontent.com/plus3it/cfn/master/psmodules/P3Utils/P3Utils.psd1"
+                            },
+                            "C:\\Program Files\\WindowsPowerShell\\Modules\\P3Utils\\P3Utils.psm1": {
+                                "source": "https://raw.githubusercontent.com/plus3it/cfn/master/psmodules/P3Utils/P3Utils.psm1"
                             }
                         }
                     },

--- a/templates/ra_rdcb_fileserver_standalone.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_standalone.template.cfn.json
@@ -1089,7 +1089,7 @@
                                             },
                                             "; ",
                                             "$CloudWatchAgentConfig =  $CloudWatchAgentScriptDir + '\\aws-cloudwatch-agent-config.json'; ",
-                                            "Start-Process msiexec.exe -Wait -ArgumentList \\\"/i $CloudWatchAgentInstaller\\\"; ",
+                                            "Start-Process msiexec.exe -ArgumentList @('/i', $CloudWatchAgentInstaller, '/qn') -NoNewWindow -PassThru -Wait; ",
                                             "$CloudWatchAgentCtl = \\\"${Env:ProgramFiles}\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\\\"; ",
                                             "& $CloudWatchAgentCtl -Action cond-restart; ",
                                             "& $CloudWatchAgentCtl -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s; ",

--- a/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
@@ -658,12 +658,14 @@
                     "configSets": {
                         "config": [
                             "join-domain",
+                            "ps-modules",
                             "install-cloudwatch-agent",
                             "setup",
                             "installRDS",
                             "finalize"
                         ],
                         "update": [
+                            "ps-modules",
                             "setup",
                             "finalize"
                         ]
@@ -709,6 +711,7 @@
                                             },
                                             " -Command \"Invoke-Command -ScriptBlock { ",
                                             "$ErrorActionPreference = 'Stop'; ",
+                                            "Import-Module P3Utils; ",
                                             "$CloudWatchAgentUri = [System.Uri]'",
                                             {
                                                 "Ref": "CloudWatchAgentUrl"
@@ -727,7 +730,7 @@
                                             },
                                             "; ",
                                             "$CloudWatchAgentConfig =  $CloudWatchAgentScriptDir + '\\aws-cloudwatch-agent-config.json'; ",
-                                            "Start-Process msiexec.exe -ArgumentList @('/i', $CloudWatchAgentInstaller, '/qn') -NoNewWindow -PassThru -Wait; ",
+                                            "Invoke-RetryCommand -Command Start-Process -ArgList @{ FilePath='msiexec.exe'; ArgumentList = @('/i', $CloudWatchAgentInstaller, '/qn'); NoNewWindow = $true; PassThru = $true; Wait = $true } -CheckExpression '$Return.Result.ExitCode -eq 0' -InitialDelay 17 -MaxDelay 59 -Verbose; ",
                                             "$CloudWatchAgentCtl = \\\"${Env:ProgramFiles}\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\\\"; ",
                                             "& $CloudWatchAgentCtl -Action cond-restart; ",
                                             "& $CloudWatchAgentCtl -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s; ",
@@ -920,6 +923,16 @@
                                     ]
                                 },
                                 "waitAfterCompletion": "forever"
+                            }
+                        }
+                    },
+                    "ps-modules": {
+                        "files": {
+                            "C:\\Program Files\\WindowsPowerShell\\Modules\\P3Utils\\P3Utils.psd1": {
+                                "source": "https://raw.githubusercontent.com/plus3it/cfn/master/psmodules/P3Utils/P3Utils.psd1"
+                            },
+                            "C:\\Program Files\\WindowsPowerShell\\Modules\\P3Utils\\P3Utils.psm1": {
+                                "source": "https://raw.githubusercontent.com/plus3it/cfn/master/psmodules/P3Utils/P3Utils.psm1"
                             }
                         }
                     },

--- a/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
@@ -166,7 +166,7 @@
                 }
             }
         },
-        "Version": "0.3.0",
+        "Version": "0.3.1",
         "cfn-lint": {
             "config": {
                 "ignore_checks": [

--- a/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
+++ b/templates/ra_rdgw_autoscale_public_lb.template.cfn.json
@@ -727,7 +727,7 @@
                                             },
                                             "; ",
                                             "$CloudWatchAgentConfig =  $CloudWatchAgentScriptDir + '\\aws-cloudwatch-agent-config.json'; ",
-                                            "Start-Process msiexec.exe -Wait -ArgumentList \\\"/i $CloudWatchAgentInstaller\\\"; ",
+                                            "Start-Process msiexec.exe -ArgumentList @('/i', $CloudWatchAgentInstaller, '/qn') -NoNewWindow -PassThru -Wait; ",
                                             "$CloudWatchAgentCtl = \\\"${Env:ProgramFiles}\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\\\"; ",
                                             "& $CloudWatchAgentCtl -Action cond-restart; ",
                                             "& $CloudWatchAgentCtl -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s; ",

--- a/templates/ra_rdsh_autoscale_internal_lb.template.cfn.json
+++ b/templates/ra_rdsh_autoscale_internal_lb.template.cfn.json
@@ -791,7 +791,7 @@
                                             },
                                             "; ",
                                             "$CloudWatchAgentConfig =  $CloudWatchAgentScriptDir + '\\aws-cloudwatch-agent-config.json'; ",
-                                            "Start-Process msiexec.exe -Wait -ArgumentList \\\"/i $CloudWatchAgentInstaller\\\"; ",
+                                            "Start-Process msiexec.exe -ArgumentList @('/i', $CloudWatchAgentInstaller, '/qn') -NoNewWindow -PassThru -Wait; ",
                                             "$CloudWatchAgentCtl = \\\"${Env:ProgramFiles}\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\\\"; ",
                                             "& $CloudWatchAgentCtl -Action cond-restart; ",
                                             "& $CloudWatchAgentCtl -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s; ",

--- a/templates/ra_rdsh_autoscale_internal_lb.template.cfn.json
+++ b/templates/ra_rdsh_autoscale_internal_lb.template.cfn.json
@@ -720,6 +720,7 @@
                     "configSets": {
                         "config": [
                             "join-domain",
+                            "ps-modules",
                             "install-cloudwatch-agent",
                             "setup",
                             "suspend-azrebalance",
@@ -727,6 +728,7 @@
                             "finalize"
                         ],
                         "update": [
+                            "ps-modules",
                             "suspend-azrebalance",
                             "setup",
                             "finalize"
@@ -773,6 +775,7 @@
                                             },
                                             " -Command \"Invoke-Command -ScriptBlock { ",
                                             "$ErrorActionPreference = 'Stop'; ",
+                                            "Import-Module P3Utils; ",
                                             "$CloudWatchAgentUri = [System.Uri]'",
                                             {
                                                 "Ref": "CloudWatchAgentUrl"
@@ -791,7 +794,7 @@
                                             },
                                             "; ",
                                             "$CloudWatchAgentConfig =  $CloudWatchAgentScriptDir + '\\aws-cloudwatch-agent-config.json'; ",
-                                            "Start-Process msiexec.exe -ArgumentList @('/i', $CloudWatchAgentInstaller, '/qn') -NoNewWindow -PassThru -Wait; ",
+                                            "Invoke-RetryCommand -Command Start-Process -ArgList @{ FilePath='msiexec.exe'; ArgumentList = @('/i', $CloudWatchAgentInstaller, '/qn'); NoNewWindow = $true; PassThru = $true; Wait = $true } -CheckExpression '$Return.Result.ExitCode -eq 0' -InitialDelay 17 -MaxDelay 59 -Verbose; ",
                                             "$CloudWatchAgentCtl = \\\"${Env:ProgramFiles}\\Amazon\\AmazonCloudWatchAgent\\amazon-cloudwatch-agent-ctl.ps1\\\"; ",
                                             "& $CloudWatchAgentCtl -Action cond-restart; ",
                                             "& $CloudWatchAgentCtl -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s; ",
@@ -1054,6 +1057,16 @@
                                     ]
                                 },
                                 "waitAfterCompletion": "forever"
+                            }
+                        }
+                    },
+                    "ps-modules": {
+                        "files": {
+                            "C:\\Program Files\\WindowsPowerShell\\Modules\\P3Utils\\P3Utils.psd1": {
+                                "source": "https://raw.githubusercontent.com/plus3it/cfn/master/psmodules/P3Utils/P3Utils.psd1"
+                            },
+                            "C:\\Program Files\\WindowsPowerShell\\Modules\\P3Utils\\P3Utils.psm1": {
+                                "source": "https://raw.githubusercontent.com/plus3it/cfn/master/psmodules/P3Utils/P3Utils.psm1"
                             }
                         }
                     },

--- a/templates/ra_rdsh_autoscale_internal_lb.template.cfn.json
+++ b/templates/ra_rdsh_autoscale_internal_lb.template.cfn.json
@@ -156,7 +156,7 @@
                 }
             }
         },
-        "Version": "0.3.0",
+        "Version": "0.3.1",
         "cfn-lint": {
             "config": {
                 "ignore_checks": [


### PR DESCRIPTION
* Updates cloudwatch agent msiexec options to be fully non-interactive (`/qn`)
* Adds a retry powershell function since software may also be installed via GPO, outside these configuration scripts, causing a race condition (msiexec will throw an error if another install is in progress)

```
Another program is being installed. Please wait until that installation is complete, and then try installing this software again.
```