### PR TITLE
Updates templates to support cfn-lint rule #I3011

### DIFF
--- a/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
+++ b/templates/db_rds_mysql_audit_plugin.element.template.cfn.json
@@ -137,6 +137,7 @@
     "Resources": {
         "RdsInstance": {
             "DeletionPolicy": "Snapshot",
+            "UpdateReplacePolicy": "Snapshot",
             "Properties": {
                 "AllocatedStorage": {
                     "Ref": "RdsDbAllocatedStorage"
@@ -184,6 +185,7 @@
         },
         "RdsOptionGroup": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "EngineName": "mysql",
                 "MajorEngineVersion": "5.6",

--- a/templates/nw_nat_gateway.element.template.cfn.json
+++ b/templates/nw_nat_gateway.element.template.cfn.json
@@ -46,6 +46,7 @@
     "Resources": {
         "NATGateway": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "AllocationId": {
                     "Fn::GetAtt": [
@@ -61,6 +62,7 @@
         },
         "NATGatewayElasticIP": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Domain": "vpc"
             },
@@ -68,6 +70,7 @@
         },
         "PrivateRoute": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DestinationCidrBlock": "0.0.0.0/0",
                 "NatGatewayId": {
@@ -81,6 +84,7 @@
         },
         "PrivateRouteTable": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Tags": [
                     {

--- a/templates/nw_nat_with_eni.element.template.cfn.json
+++ b/templates/nw_nat_with_eni.element.template.cfn.json
@@ -120,6 +120,7 @@
     "Resources": {
         "IamNatInstanceProfile": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Path": "/",
                 "Roles": [
@@ -132,6 +133,7 @@
         },
         "IamNatRole": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "AssumeRolePolicyDocument": {
                     "Statement": [
@@ -155,6 +157,7 @@
         },
         "IamNatRolePolicy": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "PolicyDocument": {
                     "Statement": [
@@ -188,6 +191,7 @@
                 }
             },
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DesiredCapacity": "1",
                 "LaunchConfigurationName": {
@@ -222,6 +226,7 @@
         },
         "NATElasticIP": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Domain": "vpc"
             },
@@ -229,6 +234,7 @@
         },
         "NATElasticIPAssociation": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "AllocationId": {
                     "Fn::GetAtt": [
@@ -244,6 +250,7 @@
         },
         "NATElasticNetworkInterface": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Description": "Network Interface for NAT Instance",
                 "GroupSet": [
@@ -279,6 +286,7 @@
         },
         "NATLaunchConfig": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "DependsOn": [
                 "NATElasticNetworkInterface"
             ],
@@ -475,6 +483,7 @@
         },
         "NATSecurityGroup": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "GroupDescription": "Enables outbound internet access for private subnets via the NAT instances",
                 "SecurityGroupIngress": [
@@ -519,6 +528,7 @@
         },
         "PrivateRoute": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DestinationCidrBlock": "0.0.0.0/0",
                 "NetworkInterfaceId": {
@@ -532,6 +542,7 @@
         },
         "PrivateRouteTable": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Tags": [
                     {

--- a/templates/nw_peered_sg.element.template.cfn.json
+++ b/templates/nw_peered_sg.element.template.cfn.json
@@ -26,6 +26,7 @@
     "Resources": {
         "RDPIngressTcp3389": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "FromPort": 3389,
                 "GroupId": {
@@ -41,6 +42,7 @@
         },
         "SSHIngressTcp22": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "FromPort": 22,
                 "GroupId": {
@@ -56,6 +58,7 @@
         },
         "VpcPeerSecurityGroup": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "GroupDescription": "Enables remote access from instances in the specified security group within the peered account",
                 "Tags": [

--- a/templates/nw_private_subnet.element.template.cfn.json
+++ b/templates/nw_private_subnet.element.template.cfn.json
@@ -47,6 +47,7 @@
     "Resources": {
         "PrivateSubnet": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "AvailabilityZone": {
                     "Ref": "AvailabilityZoneName"
@@ -86,6 +87,7 @@
         },
         "PrivateSubnetRouteTableAssociation": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "RouteTableId": {
                     "Ref": "PrivateRouteTableId"

--- a/templates/nw_public_subnet.element.template.cfn.json
+++ b/templates/nw_public_subnet.element.template.cfn.json
@@ -47,6 +47,7 @@
     "Resources": {
         "PublicSubnet": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "AvailabilityZone": {
                     "Ref": "AvailabilityZoneName"
@@ -86,6 +87,7 @@
         },
         "PublicSubnetRouteTableAssociation": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "RouteTableId": {
                     "Ref": "PublicRouteTableId"

--- a/templates/nw_r53_peered_domain.element.template.cfn.json
+++ b/templates/nw_r53_peered_domain.element.template.cfn.json
@@ -56,6 +56,7 @@
     "Resources": {
         "PeeredDcARecordSet1": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "PrivateHostedZone"
@@ -87,6 +88,7 @@
         },
         "PeeredDcARecordSet2": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "PrivateHostedZone"
@@ -118,6 +120,7 @@
         },
         "PeeredDcSrvRecordSet1": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "PrivateHostedZone"
@@ -163,6 +166,7 @@
         },
         "PeeredDcSrvRecordSet2": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "PrivateHostedZone"
@@ -208,6 +212,7 @@
         },
         "PeeredDomainARecordSet": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "HostedZoneId": {
                     "Ref": "PrivateHostedZone"
@@ -238,6 +243,7 @@
         },
         "PrivateHostedZone": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "HostedZoneConfig": {
                     "Comment": {

--- a/templates/nw_vpc_peering_connection.element.template.cfn.json
+++ b/templates/nw_vpc_peering_connection.element.template.cfn.json
@@ -120,6 +120,7 @@
         "VpcPeerRoute1": {
             "Condition": "RouteTable1",
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DestinationCidrBlock": {
                     "Ref": "VpcPeerCidr"
@@ -136,6 +137,7 @@
         "VpcPeerRoute2": {
             "Condition": "RouteTable2",
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DestinationCidrBlock": {
                     "Ref": "VpcPeerCidr"
@@ -152,6 +154,7 @@
         "VpcPeerRoute3": {
             "Condition": "RouteTable3",
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DestinationCidrBlock": {
                     "Ref": "VpcPeerCidr"
@@ -168,6 +171,7 @@
         "VpcPeerRoute4": {
             "Condition": "RouteTable4",
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "DestinationCidrBlock": {
                     "Ref": "VpcPeerCidr"
@@ -183,6 +187,7 @@
         },
         "VpcPeeringConnection": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "PeerOwnerId": {
                     "Ref": "VpcPeerAccountId"

--- a/templates/nw_vpc_with_igw.element.template.cfn.json
+++ b/templates/nw_vpc_with_igw.element.template.cfn.json
@@ -41,6 +41,7 @@
     "Resources": {
         "AttachGateway": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "InternetGatewayId": {
                     "Ref": "InternetGateway"
@@ -53,6 +54,7 @@
         },
         "InternetGateway": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Tags": [
                     {
@@ -67,6 +69,7 @@
         },
         "PublicRoute": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "DependsOn": "AttachGateway",
             "Properties": {
                 "DestinationCidrBlock": "0.0.0.0/0",
@@ -81,6 +84,7 @@
         },
         "PublicRouteTable": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "Tags": [
                     {
@@ -106,6 +110,7 @@
         },
         "VPC": {
             "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
             "Properties": {
                 "CidrBlock": {
                     "Ref": "CIDRVPC"

--- a/templates/ra_rdcb_fileserver_ha.template.cfn.json
+++ b/templates/ra_rdcb_fileserver_ha.template.cfn.json
@@ -493,6 +493,7 @@
         },
         "DataVolume": {
             "DeletionPolicy": "Snapshot",
+            "UpdateReplacePolicy": "Snapshot",
             "Properties": {
                 "AvailabilityZone": {
                     "Ref": "Ec2SubnetAz"


### PR DESCRIPTION
cfn-lint 0.26.1 adds new rule [I3011](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#I3011) to check stateful resources have a set UpdateReplacePolicy/DeletionPolicy (pull #[1232](https://github-redirect.dependabot.com/aws-cloudformation/cfn-python-lint/pull/1232))

This PR updates the templates to support this new rule. 